### PR TITLE
feat: 자기소개 수정 기능 추가

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -72,6 +72,25 @@ class SpreadSheetClient:
 
         sheet.update(f"A{row_number}:F{row_number}", [values])
 
+    def update_user(self, sheet_name: str, values: list[str]) -> None:
+        """유저 정보를 시트에 업데이트 합니다."""
+        # TODO: 추후 업데이트 함수 통합하기
+        sheet = self._sheets[sheet_name]
+        records = sheet.get_all_records()
+
+        target_record = dict()
+        row_number = 2  # 1은 인덱스가 0부터 시작하기 때문이며 나머지 1은 시드 헤더 행이 있기 때문.
+        for idx, record in enumerate(records):
+            if values[0] == record["user_id"]:
+                target_record = record
+                row_number += idx
+                break
+
+        if not target_record:
+            logger.error(f"시트에 해당 값이 존재하지 않습니다. {values}")
+
+        sheet.update(f"A{row_number}:E{row_number}", [values])
+
     def clear(self, sheet_name: str) -> None:
         """해당 시트의 모든 데이터를 삭제합니다."""
         self._sheets[sheet_name].clear()

--- a/app/models.py
+++ b/app/models.py
@@ -91,6 +91,15 @@ class User(BaseModel):
         # 최근 제출한 콘텐츠의 날짜가 직전 마감일 초과, 현재 날짜 이하 라면 제출했다고 판단한다.
         return latest_due_date < recent_content.date <= now_date
 
+    def to_list_for_sheet(self) -> list[str]:
+        return [
+            self.user_id,
+            self.name,
+            self.channel_name,
+            self.channel_id,
+            self.intro,
+        ]
+
 
 class StoreModel(BaseModel):
     ...

--- a/app/slack/contents/events.py
+++ b/app/slack/contents/events.py
@@ -714,3 +714,10 @@ async def bookmark_submit_search_view(
             },
         }
     )
+
+
+async def update_user_view(
+    ack, body, say, client, user_id: str, service: SlackService
+) -> None:
+    """북마크 검색 완료"""
+    ...

--- a/app/slack/contents/events.py
+++ b/app/slack/contents/events.py
@@ -809,10 +809,3 @@ async def bookmark_submit_search_view(
             },
         }
     )
-
-
-async def update_user_view(
-    ack, body, say, client, user_id: str, service: SlackService
-) -> None:
-    """북마크 검색 완료"""
-    ...

--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -112,7 +112,6 @@ async def handle_error(error, body):
         trigger_id=body["trigger_id"],
         view={
             "type": "modal",
-            "private_metadata": body["channel_id"],
             "title": {"type": "plain_text", "text": "잠깐!"},
             "blocks": [
                 {
@@ -159,6 +158,8 @@ async def handle_member_joined_channel(ack, body) -> None:
 app.command("/제출")(contents_events.submit_command)
 app.view("submit_view")(contents_events.submit_view)
 app.action("intro_modal")(contents_events.open_intro_modal)
+app.view("edit_intro_view")(contents_events.edit_intro_view)
+app.view("submit_intro_view")(contents_events.submit_intro_view)
 app.action("contents_modal")(contents_events.contents_modal)
 app.action("bookmark_modal")(contents_events.bookmark_modal)
 app.view("bookmark_view")(contents_events.bookmark_view)
@@ -186,6 +187,8 @@ event_descriptions = {
     "/제출": "글 제출 시작",
     "submit_view": "글 제출 완료",
     "intro_modal": "다른 유저의 자기소개 확인",
+    "edit_intro_view": "자기소개 수정 시작",
+    "submit_intro_view": "자기소개 수정 완료",
     "contents_modal": "다른 유저의 제출한 글 목록 확인",
     "bookmark_modal": "북마크 저장 시작",
     "bookmark_view": "북마크 저장 완료",

--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -171,6 +171,8 @@ app.command("/북마크")(contents_events.bookmark_command)
 app.view("bookmark_search_view")(contents_events.bookmark_search_view)
 app.action("bookmark_overflow_action")(contents_events.open_overflow_action)
 app.view("bookmark_submit_search_view")(contents_events.bookmark_submit_search_view)
+# TODO: 추후 도메인 분리
+app.view("update_user_view")(contents_events.update_user_view)
 
 # core
 app.event("app_mention")(core_events.handle_app_mention)

--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -172,8 +172,6 @@ app.command("/북마크")(contents_events.bookmark_command)
 app.view("bookmark_search_view")(contents_events.bookmark_search_view)
 app.action("bookmark_overflow_action")(contents_events.open_overflow_action)
 app.view("bookmark_submit_search_view")(contents_events.bookmark_submit_search_view)
-# TODO: 추후 도메인 분리
-app.view("update_user_view")(contents_events.update_user_view)
 
 # core
 app.event("app_mention")(core_events.handle_app_mention)

--- a/app/slack/repositories.py
+++ b/app/slack/repositories.py
@@ -47,6 +47,7 @@ class SlackRepository:
 
     def update(self, user: models.User) -> None:
         """유저의 콘텐츠를 업데이트합니다."""
+        # TODO: upload 로 이름 변경 필요
         if not user.contents:
             raise BotException("업데이트 대상 content 가 없어요.")
         store.content_upload_queue.append(user.recent_content.to_list_for_sheet())
@@ -149,3 +150,16 @@ class SlackRepository:
             df.loc[df["content_id"] == content_id, "updated_at"] = tz_now_to_str()
 
         df.to_csv("store/bookmark.csv", index=False)
+
+    def update_user(
+        self,
+        user_id: str,
+        new_intro: str,
+    ) -> None:
+        """유저 정보를 업데이트합니다."""
+        df = pd.read_csv("store/users.csv")
+        df.loc[df["user_id"] == user_id, "intro"] = new_intro
+        df.to_csv("store/users.csv", index=False)
+
+        if user := self._get_user(user_id):
+            store.user_update_queue.append(user.to_list_for_sheet())

--- a/app/slack/services.py
+++ b/app/slack/services.py
@@ -615,3 +615,13 @@ class SlackService:
         bookmark = self._user_repo.get_bookmark(user_id, content_id, status=new_status)
         if bookmark:
             store.bookmark_update_queue.append(bookmark)
+
+    def update_user(
+        self,
+        user_id: str,
+        new_intro: str,
+    ) -> None:
+        """사용자의 자기소개를 수정합니다."""
+        if self._user.user_id != user_id:
+            raise BotException("본인의 자기소개만 수정할 수 있습니다.")
+        self._user_repo.update_user(user_id, new_intro)

--- a/app/store.py
+++ b/app/store.py
@@ -7,6 +7,7 @@ from app.models import Bookmark
 content_upload_queue: list[list[str]] = []
 bookmark_upload_queue: list[list[str]] = []
 bookmark_update_queue: list[Bookmark] = []  # TODO: 추후 타입 수정 필요
+user_update_queue: list[list[str]] = []
 
 
 class Store:
@@ -73,6 +74,19 @@ class Store:
                 body={"bookmark_update_queue": bookmark_update_queue},
             )
             bookmark_update_queue = []
+
+        global user_update_queue
+        if user_update_queue:
+            for values in user_update_queue:
+                self._client.update_user(sheet_name="users", values=values)
+            log_event(
+                actor="system",
+                event="updated_user_introduction",
+                type="user",
+                description=f"{len(user_update_queue)}개 유저 자기소개 업데이트",
+                body={"user_update_queue": user_update_queue},
+            )
+            user_update_queue = []
 
     def backup(self, table_name: str) -> None:
         values = self.read(table_name)


### PR DESCRIPTION
기존 자기소개 내용을 수정하거나 업데이트하고 싶어하는 사용자들이 있었고,  실제 수정을 요청하는 경우도 있었습니다.
이에 따라 자기소개 수정 기능을 제공하여, 사용자가 직접 자기소개 내용을 수정할 수 있도록 개선합니다.

자기소개는 본인의 자기소개만 수정할 수 있습니다.
최대 2000자 까지만 작성할 수 있습니다. 
수정 후, 다시 [자기소개 보기] 버튼을 클릭하여 변경된 내용을 확인할 수 있습니다.