### PR TITLE
feat: 기존 메시지에 감지 키워드를 추가할 경우 메시지 저장

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,3 @@ repos:
           - "slack_bolt"
           - "fastapi"
           - "types-requests"
-          
-  # - repo: https://github.com/Daco2020/auto-commit-msg.git
-  #   rev: v0.1.3
-  #   hooks:
-  #     - id: "auto-commit-msg"

--- a/app/client.py
+++ b/app/client.py
@@ -47,6 +47,10 @@ class SpreadSheetClient:
         sheet.clear()
         sheet.append_rows(values)
 
+    def clear(self, sheet_name: str) -> None:
+        """해당 시트의 모든 데이터를 삭제합니다."""
+        self._sheets[sheet_name].clear()
+
     def upload(self, sheet_name: str, values: list[list[str]]) -> None:
         sheet = self._sheets[sheet_name]
         sheet.append_rows(values)
@@ -93,6 +97,21 @@ class SpreadSheetClient:
 
         sheet.update(f"A{row_number}:E{row_number}", [values])
 
-    def clear(self, sheet_name: str) -> None:
-        """해당 시트의 모든 데이터를 삭제합니다."""
-        self._sheets[sheet_name].clear()
+    def update_archive_message(self, sheet_name: str, values: list[str]) -> None:
+        """아카이브 메시지 정보를 시트에 업데이트 합니다."""
+        # TODO: 추후 업데이트 함수 통합하기
+        sheet = self._sheets[sheet_name]
+        records = sheet.get_all_records()
+
+        target_record = dict()
+        row_number = 2  # 1은 인덱스가 0부터 시작하기 때문이며 나머지 1은 시드 헤더 행이 있기 때문.
+        for idx, record in enumerate(records):
+            if values[0] == record["ts"]:
+                target_record = record
+                row_number += idx
+                break
+
+        if not target_record:
+            logger.error(f"시트에 해당 값이 존재하지 않습니다. {values}")
+
+        sheet.update(f"A{row_number}:E{row_number}", [values])

--- a/app/client.py
+++ b/app/client.py
@@ -106,7 +106,7 @@ class SpreadSheetClient:
         target_record = dict()
         row_number = 2  # 1은 인덱스가 0부터 시작하기 때문이며 나머지 1은 시드 헤더 행이 있기 때문.
         for idx, record in enumerate(records):
-            if values[0] == record["ts"]:
+            if values[0] == str(record["ts"]):
                 target_record = record
                 row_number += idx
                 break
@@ -114,4 +114,4 @@ class SpreadSheetClient:
         if not target_record:
             logger.error(f"시트에 해당 값이 존재하지 않습니다. {values}")
 
-        sheet.update(f"A{row_number}:E{row_number}", [values])
+        sheet.update(f"A{row_number}:G{row_number}", [values])

--- a/app/models.py
+++ b/app/models.py
@@ -252,7 +252,7 @@ class ArchiveMessage(StoreModel):
     user_id: str
     message: str
     file_urls: str
-    created_at: str = Field(default_factory=tz_now_to_str)
+    updated_at: str = Field(default_factory=tz_now_to_str)
 
     def to_list_for_csv(self) -> list[str]:
         return [
@@ -262,7 +262,7 @@ class ArchiveMessage(StoreModel):
             self.user_id,
             self.message,
             self.file_urls,
-            self.created_at,
+            self.updated_at,
         ]
 
     def to_list_for_sheet(self) -> list[str]:
@@ -273,5 +273,5 @@ class ArchiveMessage(StoreModel):
             self.user_id,
             self.message,
             self.file_urls,
-            self.created_at,
+            self.updated_at,
         ]

--- a/app/slack/community/events.py
+++ b/app/slack/community/events.py
@@ -11,7 +11,7 @@ import re
 async def trigger_command(
     ack, body, say, client: AsyncWebClient, user_id: str, service: SlackService
 ) -> None:
-    """메시지 트리거 등록"""
+    """키워드 감지 등록"""
     await ack()
 
     await client.views_open(
@@ -20,7 +20,7 @@ async def trigger_command(
             "type": "modal",
             "private_metadata": body["channel_id"],
             "callback_id": "trigger_view",
-            "title": {"type": "plain_text", "text": "메시지 트리거 등록"},
+            "title": {"type": "plain_text", "text": "키워드 감지 등록"},
             "submit": {"type": "plain_text", "text": "등록"},
             "blocks": [
                 {
@@ -28,7 +28,7 @@ async def trigger_command(
                     "block_id": "description_section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"메시지 트리거를 등록하면 <#{body['channel_id']}> 에서 트리거가 포함된 메시지를 저장할 수 있어요. 😉",
+                        "text": f"키워드 감지를 등록하면 <#{body['channel_id']}> 에서 키워드가 포함된 메시지를 저장할 수 있어요. 😉",  # noqa E501
                     },
                 },
                 {
@@ -45,7 +45,7 @@ async def trigger_command(
                     },
                     "label": {
                         "type": "plain_text",
-                        "text": "'$'으로 시작하는 트리거 단어를 입력해주세요. \n예) $회고, $기록, $메모, ...",
+                        "text": "'$'으로 시작하는 키워드를 입력해주세요. \n예) $회고, $기록, $메모, ...",
                         "emoji": True,
                     },
                 },
@@ -57,7 +57,7 @@ async def trigger_command(
 async def trigger_view(
     ack, body, client, view, say, user_id: str, service: SlackService
 ) -> None:
-    """메시지 트리거 생성"""
+    """키워드 감지 생성"""
     await ack()
 
     user_id = body["user"]["id"]
@@ -73,13 +73,13 @@ async def trigger_view(
 
     error_message = ""
     if trigger_word[0] != "$":
-        error_message = "트리거 단어는 $으로 시작해주세요."
+        error_message = "키워드는 $으로 시작해주세요."
     elif len(trigger_word) <= 1:
-        error_message = "트리거 단어는 두글자 이상으로 만들어주세요."
+        error_message = "키워드는 두글자 이상으로 만들어주세요."
     elif " " in trigger_word:
-        error_message = "트리거 단어는 공백을 사용할 수 없어요."
+        error_message = "키워드는 공백을 사용할 수 없어요."
     elif is_similar_word:
-        error_message = f"이미 유사한 트리거 단어가 존재해요. {','.join(existing_trigger_words)} 과(와) 구별되는 트리거 단어를 입력해주세요."
+        error_message = f"이미 유사한 키워드가 존재해요. {','.join(existing_trigger_words)} 과(와) 구별되는 키워드를 입력해주세요."  # noqa E501
 
     if error_message:
         await ack(
@@ -96,20 +96,19 @@ async def handle_trigger_message(
     event: dict[str, Any],
     service: SlackService,
 ) -> None:
+    channel_id = event["channel"]
+    is_messgae_changed = False
+
     if event.get("subtype") == "message_changed":
-        message = event["message"]["text"]  # 수정된 메시지
-        ts = event["message"]["ts"]
-        channel_id = event["channel"]
-        user_id = event["message"]["user"]
-        files = event["message"].get("files")
-        file_urls = [file.get("url_private") for file in files] if files else []
-    else:
-        message = event["text"]  # 새로운 메시지
-        ts = event["ts"]
-        channel_id = event["channel"]
-        user_id = event["user"]
-        files = event.get("files")
-        file_urls = [file.get("url_private") for file in files] if files else []
+        #  메시지 수정 이벤트는 event["message"] 안에 있습니다.
+        is_messgae_changed = True
+        event = event["message"]
+
+    message = event["text"]
+    ts = event["ts"]
+    user_id = event["user"]
+    files = event.get("files")
+    file_urls = [file.get("url_private") for file in files] if files else []
 
     trigger = service.get_trigger_message(channel_id, message)
     if not trigger:
@@ -117,15 +116,24 @@ async def handle_trigger_message(
 
     message = convert_user_id_to_name(message)
 
-    # TODO: update_archive_message 추가하기
-    service.create_archive_message(
-        ts=ts,
-        channel_id=channel_id,
-        message=message,
-        user_id=user_id,
-        trigger_word=trigger.trigger_word,
-        file_urls=file_urls,
-    )
+    if is_messgae_changed:
+        is_created = service.update_archive_message(
+            ts=ts,
+            channel_id=channel_id,
+            message=message,
+            user_id=user_id,
+            trigger_word=trigger.trigger_word,
+            file_urls=file_urls,
+        )
+    else:
+        service.create_archive_message(
+            ts=ts,
+            channel_id=channel_id,
+            message=message,
+            user_id=user_id,
+            trigger_word=trigger.trigger_word,
+            file_urls=file_urls,
+        )
     try:
         await client.reactions_add(
             channel=channel_id,
@@ -141,7 +149,13 @@ async def handle_trigger_message(
         channel_id, trigger.trigger_word, user_id
     )
 
-    response_message = f"<@{user_id}>님의 {len(archive_messages)}번째 `{trigger.trigger_word}` 메시지를 저장했어요. 😉"
+    if not is_messgae_changed or is_created:
+        # 새로운 메시지 or 키워드를 추가한 메시지
+        response_message = f"<@{user_id}>님의 {len(archive_messages)}번째 `{trigger.trigger_word}` 메시지를 저장했어요. 😉"  # noqa E501
+    else:
+        # 수정한 메시지
+        response_message = f"<@{user_id}>님의 `{trigger.trigger_word}` 메시지를 수정했어요. 😉"
+
     await client.chat_postMessage(
         channel=channel_id,
         thread_ts=ts,

--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -137,7 +137,7 @@ async def handle_error(error, body):
 
 
 # community
-app.command("/메시지트리거등록")(community_events.trigger_command)
+app.command("/키워드감지등록")(community_events.trigger_command)
 app.view("trigger_view")(community_events.trigger_view)
 
 
@@ -217,6 +217,6 @@ event_descriptions = {
     "/제출내역": "제출내역 조회",
     "/관리자": "관리자 메뉴 조회",
     "/도움말": "도움말 조회",
-    "/메시지트리거등록": "메시지 트리거 등록 시작",
-    "/trigger_view": "메시지 트리거 등록 완료",
+    "/키워드감지등록": "키워드 감지 등록 시작",
+    "/trigger_view": "키워드 감지 등록 완료",
 }

--- a/app/slack/repositories.py
+++ b/app/slack/repositories.py
@@ -213,6 +213,7 @@ class SlackRepository:
         """아카이브 메시지를 업데이트합니다."""
         df = pd.read_csv("store/archive_message.csv")
         df.loc[df["ts"] == float(ts), "message"] = new_message
+        df.loc[df["ts"] == float(ts), "updated_at"] = tz_now_to_str()
         df.to_csv("store/archive_message.csv", index=False, quoting=csv.QUOTE_ALL)
 
     def get_archive_message(

--- a/app/slack/services.py
+++ b/app/slack/services.py
@@ -644,7 +644,7 @@ class SlackService:
         channel_id: str,
         trigger_word: str,
     ) -> models.TriggerMessage:
-        """트리거 메시지를 생성합니다."""
+        """키워드 메시지를 생성합니다."""
         trigger_message = models.TriggerMessage(
             user_id=user_id,
             channel_id=channel_id,
@@ -657,7 +657,7 @@ class SlackService:
     def fetch_trigger_messages(
         self, channel_id: str | None = None
     ) -> list[models.TriggerMessage]:
-        """트리거 메시지를 가져옵니다."""
+        """키워드 메시지를 가져옵니다."""
         triggers = self._user_repo.fetch_trigger_messages()
 
         if not channel_id:
@@ -668,7 +668,7 @@ class SlackService:
     def get_trigger_message(
         self, channel_id: str, message: str
     ) -> models.TriggerMessage | None:
-        """채널과 단어가 일치하는 트리거를 조회합니다."""
+        """채널과 단어가 일치하는 키워드를 조회합니다."""
         triggers = self._user_repo.fetch_trigger_messages()
 
         for tirgger in triggers:
@@ -704,3 +704,38 @@ class SlackService:
     ) -> list[models.ArchiveMessage]:
         """아카이브 메시지를 가져옵니다."""
         return self._user_repo.fetch_archive_messages(channel_id, trigger_word, user_id)
+
+    def update_archive_message(
+        self,
+        ts: str,
+        channel_id: str,
+        message: str,
+        user_id: str,
+        trigger_word: str,
+        file_urls: list[str],
+    ) -> bool:
+        """아카이브 메시지를 수정합니다."""
+        self._user_repo.update_archive_message(ts, message)
+
+        if archive_message := self._user_repo.get_archive_message(ts):
+            store.archive_message_update_queue.append(
+                archive_message.to_list_for_sheet()
+            )
+            is_created = False
+        else:
+            # 수정이 아닌, 기존 메시지에 키워드를 추가한 경우 새로 생성
+            archive_message = models.ArchiveMessage(
+                ts=ts,
+                channel_id=channel_id,
+                message=message,
+                user_id=user_id,
+                trigger_word=trigger_word,
+                file_urls=",".join(file_urls),
+            )
+            self._user_repo.create_archive_message(archive_message)
+            store.archive_message_upload_queue.append(
+                archive_message.to_list_for_sheet()
+            )
+            is_created = True
+
+        return is_created

--- a/app/store.py
+++ b/app/store.py
@@ -120,7 +120,9 @@ class Store:
         global archive_message_update_queue
         if archive_message_update_queue:
             for values in archive_message_update_queue:
-                self._client.update_archive_message(sheet_name="users", values=values)
+                self._client.update_archive_message(
+                    sheet_name="archive_message", values=values
+                )
             log_event(
                 actor="system",
                 event="updated_archive_message",

--- a/app/store.py
+++ b/app/store.py
@@ -10,6 +10,7 @@ bookmark_update_queue: list[Bookmark] = []  # TODO: 추후 타입 수정 필요
 user_update_queue: list[list[str]] = []
 trigger_message_upload_queue: list[list[str]] = []
 archive_message_upload_queue: list[list[str]] = []
+archive_message_update_queue: list[list[str]] = []
 
 
 class Store:
@@ -99,7 +100,7 @@ class Store:
                 actor="system",
                 event="uploaded_trigger_message",
                 type="community",
-                description=f"{len(trigger_message_upload_queue)}개 트리거 메시지 업로드",
+                description=f"{len(trigger_message_upload_queue)}개 키워드 메시지 업로드",
                 body={"trigger_message_upload_queue": trigger_message_upload_queue},
             )
             trigger_message_upload_queue = []
@@ -115,6 +116,19 @@ class Store:
                 body={"archive_message_upload_queue": archive_message_upload_queue},
             )
             archive_message_upload_queue = []
+
+        global archive_message_update_queue
+        if archive_message_update_queue:
+            for values in archive_message_update_queue:
+                self._client.update_archive_message(sheet_name="users", values=values)
+            log_event(
+                actor="system",
+                event="updated_archive_message",
+                type="user",
+                description=f"{len(archive_message_update_queue)}개 아카이브 메시지 업데이트",
+                body={"archive_message_update_queue": archive_message_update_queue},
+            )
+            archive_message_update_queue = []
 
     def backup(self, table_name: str) -> None:
         values = self.read(table_name)


### PR DESCRIPTION
슬랙 메시지에 특정 키워드를 추가하면 또봇이 이를 감지하여 메시지를 저장하는 기능이 있음.
하지만 키워드를 누락한 경우 다시 메시지를 편집하여 추가할지라도 메시지를 저장하지 못함.

하여 키워드를 새로 추가하는 경우에는 이를 감지하여 메시지를 저장하도록 수정.

시연 영상
![screencast 2024-01-21 23-30-15](https://github.com/Daco2020/ttobot/assets/76890895/b746aafc-685d-4aff-9cbe-6e9872387a3c)

