### PR TITLE
feat: 제출 메시지에 대한 ts 컬럼 추가

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -127,6 +127,7 @@ class Content(StoreModel):
     category: str = ""
     tags: str = ""
     curation_flag: str = "N"  # "Y", "N"
+    ts: str = ""
 
     def __hash__(self) -> int:
         return hash(self.content_id)
@@ -165,6 +166,7 @@ class Content(StoreModel):
             self.type,
             self.tags,
             self.curation_flag,
+            self.ts,
         ]
 
     def to_list_for_sheet(self) -> list[str]:
@@ -179,6 +181,7 @@ class Content(StoreModel):
             self.type,
             self.tags,
             self.curation_flag,
+            self.ts,
         ]
 
     def get_round(self) -> int:

--- a/app/slack/services.py
+++ b/app/slack/services.py
@@ -66,9 +66,12 @@ class SlackService:
             tags=self._get_tags(view),
             curation_flag=self._get_curation_flag(view),
         )
+        return content
+
+    async def update_user_content(self, content: models.Content) -> None:
+        """유저의 콘텐츠를 업데이트합니다."""
         self._user.contents.append(content)
         self._user_repo.update(self._user)
-        return content
 
     async def create_pass_content(self, ack, body, view) -> models.Content:
         """패스 콘텐츠를 생성합니다."""
@@ -79,8 +82,6 @@ class SlackService:
             description=self._get_description(view),
             type="pass",
         )
-        self._user.contents.append(content)
-        self._user_repo.update(self._user)
         return content
 
     def get_chat_message(self, content: models.Content) -> str:

--- a/app/views/community.py
+++ b/app/views/community.py
@@ -47,6 +47,7 @@ async def fetch_contents(
             "dt",
             "category",
             "tags",
+            "ts",
         ],
     )
     if category:


### PR DESCRIPTION
제출한 메시지의 ts(id) 를 추가로 저장합니다.

슬랙 봇 글빼미를 통해 글 제출 기준에 부합하지 않는 글에 대해서 자동응답 기능을 추가 할 예정입니다.
이를 위해서 제출 메시지의 id 인 ts 가 필요합니다. 
하여 ts 저장 로직을 구현합니다.
