### PR TITLE
fix: 유효성 검사 후 패스모달 열기

### DIFF
--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -22,9 +22,7 @@ app = AsyncApp(token=settings.BOT_TOKEN)
 
 
 @app.middleware
-async def log_event_middleware(
-    req: BoltRequest, resp: BoltResponse, next: Callable
-) -> None:
+async def log_event_middleware(req: BoltRequest, resp: BoltResponse, next: Callable) -> None:
     """이벤트를 로그로 남깁니다."""
     body = req.body
     if body.get("command"):
@@ -58,9 +56,7 @@ async def log_event_middleware(
 
 
 @app.middleware
-async def inject_service_middleware(
-    req: BoltRequest, resp: BoltResponse, next: Callable
-) -> None:
+async def inject_service_middleware(req: BoltRequest, resp: BoltResponse, next: Callable) -> None:
     """서비스 객체를 주입합니다."""
     event = req.context.get("event")
     user_id = req.context.user_id
@@ -126,7 +122,7 @@ async def handle_error(error, body):
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": f"🥲 {message}\n\n👉🏼 문제가 해결되지 않는다면 <#{settings.SUPPORT_CHANNEL}> 채널로 문의해주세요! ",  # noqa E501
+                            "text": f"🥲 {message}\n\n👉🏼 궁금한 사항은 <#{settings.SUPPORT_CHANNEL}> 채널로 문의해주세요.",  # noqa E501
                         },
                     }
                 ],
@@ -145,9 +141,7 @@ app.view("trigger_view")(community_events.trigger_view)
 
 
 @app.event("message")
-async def handle_message(
-    ack, body, client: AsyncWebClient, service: SlackService
-) -> None:
+async def handle_message(ack, body, client: AsyncWebClient, service: SlackService) -> None:
     await ack()
 
     event = body.get("event", {})


### PR DESCRIPTION
모바일 사용자에게는 패스에 대한 에러 메시지가 전달되지 않고 있었습니다.
하여 기존 유효성 검사 위치를 모달 열기 전으로 변경하고, 에러 메시지가 아닌 에러 모달을 통해 전달하도록 변경합니다.

변경전, 데스크탑 화면
![image](https://github.com/Daco2020/ttobot/assets/76890895/de851417-86cc-45c8-ab1a-189781d95a82)

변경전, 모바일 화면
![image](https://github.com/Daco2020/ttobot/assets/76890895/f3b9a5f6-3be0-4229-9f9a-55b0f6e15982)

변경후, 공통
![image](https://github.com/Daco2020/ttobot/assets/76890895/5a48ab87-c1f1-4c82-8a90-29f5d1417c90)
