### PR TITLE
refactor: 북마크 content_id 제거 및 author_user_id, content_ts 추가

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -63,6 +63,7 @@ class SpreadSheetClient:
 
     def update(self, sheet_name: str, obj: StoreModel) -> None:
         """해당 객체 정보를 시트에 업데이트 합니다."""
+        # TODO: 현재는 북마크에 대한 업데이트만 가능하도록 구현되어 있음
         sheet = self._sheets[sheet_name]
         records = sheet.get_all_records()
 
@@ -71,7 +72,7 @@ class SpreadSheetClient:
         for idx, record in enumerate(records):
             if (  # TODO: 추후 pk 를 추가하여 조건 바꾸기
                 obj.user_id == record["user_id"]  # type: ignore
-                and obj.content_id == record["content_id"]  # type: ignore
+                and obj.content_ts == record["content_ts"]  # type: ignore
             ):
                 target_record = record
                 row_number += idx

--- a/app/models.py
+++ b/app/models.py
@@ -256,7 +256,7 @@ class BookmarkStatusEnum(str, Enum):
 class Bookmark(StoreModel):
     user_id: str
     content_user_id: str
-    content_ts: str  # id 역할을 한다.
+    content_ts: str  # content fk 역할을 한다.
     note: str = ""
     status: BookmarkStatusEnum = BookmarkStatusEnum.ACTIVE
     created_at: str = Field(default_factory=tz_now_to_str)

--- a/app/models.py
+++ b/app/models.py
@@ -255,7 +255,7 @@ class BookmarkStatusEnum(str, Enum):
 
 class Bookmark(StoreModel):
     user_id: str
-    author_user_id: str
+    content_user_id: str
     content_ts: str  # id 역할을 한다.
     note: str = ""
     status: BookmarkStatusEnum = BookmarkStatusEnum.ACTIVE
@@ -265,7 +265,7 @@ class Bookmark(StoreModel):
     def to_list_for_csv(self) -> list[str]:
         return [
             self.user_id,
-            self.author_user_id,
+            self.content_user_id,
             self.content_ts,
             self.note,
             self.status,
@@ -276,7 +276,7 @@ class Bookmark(StoreModel):
     def to_list_for_sheet(self) -> list[str]:
         return [
             self.user_id,
-            self.author_user_id,
+            self.content_user_id,
             self.content_ts,
             self.note,
             self.status,

--- a/app/models.py
+++ b/app/models.py
@@ -191,17 +191,12 @@ class Content(StoreModel):
     ts: str = ""
 
     def __hash__(self) -> int:
-        return hash(self.content_id)
+        return hash(self.ts)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Content):
             return NotImplemented
-        return self.content_id == other.content_id
-
-    @property
-    def content_id(self) -> str:
-        """컨텐츠 아이디를 반환합니다."""
-        return f"{self.user_id}:{self.dt}"
+        return self.ts == other.ts
 
     @property
     def dt_(self) -> datetime.datetime:
@@ -260,7 +255,8 @@ class BookmarkStatusEnum(str, Enum):
 
 class Bookmark(StoreModel):
     user_id: str
-    content_id: str  # user_id:dt 형식의 유니크 키
+    author_user_id: str
+    content_ts: str  # id 역할을 한다.
     note: str = ""
     status: BookmarkStatusEnum = BookmarkStatusEnum.ACTIVE
     created_at: str = Field(default_factory=tz_now_to_str)
@@ -269,7 +265,8 @@ class Bookmark(StoreModel):
     def to_list_for_csv(self) -> list[str]:
         return [
             self.user_id,
-            self.content_id,
+            self.author_user_id,
+            self.content_ts,
             self.note,
             self.status,
             self.created_at,
@@ -279,7 +276,8 @@ class Bookmark(StoreModel):
     def to_list_for_sheet(self) -> list[str]:
         return [
             self.user_id,
-            self.content_id,
+            self.author_user_id,
+            self.content_ts,
             self.note,
             self.status,
             self.created_at,

--- a/app/slack/events/community.py
+++ b/app/slack/events/community.py
@@ -1,5 +1,4 @@
 import asyncio
-import orjson
 import requests
 from slack_sdk.web.async_client import AsyncWebClient
 from app.exception import BotException
@@ -20,6 +19,7 @@ from slack_sdk.models.blocks import (
     ButtonElement,
 )
 from app.config import settings
+from app.utils import dict_to_json_str, json_str_to_dict
 
 # TODO: 커피 챗 인증 횟수 확인 방법 강구. 앱 홈 화면에 표시할 수 있도록?
 
@@ -124,12 +124,12 @@ async def submit_coffee_chat_proof_button(
     """커피챗 인증을 제출합니다."""
     await ack()
 
-    private_metadata = orjson.dumps(
+    private_metadata = dict_to_json_str(
         {
             "ephemeral_url": body["response_url"],
             "message_ts": body["actions"][0]["value"],
         }
-    ).decode("utf-8")
+    )
 
     await client.views_open(
         trigger_id=body["trigger_id"],
@@ -167,7 +167,7 @@ async def submit_coffee_chat_proof_view(
     """커피챗 인증을 처리합니다."""
     await ack()
 
-    private_metadata = orjson.loads(body["view"]["private_metadata"])
+    private_metadata = json_str_to_dict(body["view"]["private_metadata"])
     ephemeral_url = private_metadata["ephemeral_url"]
     message_ts = private_metadata["message_ts"]
 

--- a/app/slack/events/contents.py
+++ b/app/slack/events/contents.py
@@ -1,4 +1,3 @@
-import ast
 import asyncio
 import re
 import requests
@@ -937,20 +936,20 @@ def _fetch_bookmark_blocks(
                     action_id="bookmark_overflow_action",
                     options=[
                         Option(
-                            value=str(
-                                dict(
-                                    action="remove_bookmark",
-                                    content_ts=content.ts,
-                                )
+                            value=dict_to_json_str(
+                                {
+                                    "action": "remove_bookmark",
+                                    "content_ts": content.ts,
+                                }
                             ),
                             text="북마크 취소📌",
                         ),
                         Option(
-                            value=str(
-                                dict(
-                                    action="view_note",
-                                    content_ts=content.ts,
-                                )
+                            value=dict_to_json_str(
+                                {
+                                    "action": "view_note",
+                                    "content_ts": content.ts,
+                                }
                             ),
                             text="메모 보기✏️",
                         ),
@@ -987,9 +986,7 @@ async def open_overflow_action(
 
     title = ""
     text = ""
-    value = ast.literal_eval(
-        body["actions"][0]["selected_option"]["value"]
-    )  # TODO: ast.literal_eval 를 orjson 을 사용하도록 변경
+    value = json_str_to_dict(body["actions"][0]["selected_option"]["value"])
     if value["action"] == "remove_bookmark":
         title = "북마크 취소📌"
         service.update_bookmark(

--- a/app/slack/repositories.py
+++ b/app/slack/repositories.py
@@ -114,12 +114,12 @@ class SlackRepository:
     def get_bookmark(
         self,
         user_id: str,
-        content_id: str,
+        content_ts: str,
         status: models.BookmarkStatusEnum = models.BookmarkStatusEnum.ACTIVE,
     ) -> models.Bookmark | None:
         bookmarks = self.fetch_bookmarks(user_id, status)
         for bookmark in bookmarks:
-            if bookmark.content_id == content_id:
+            if bookmark.content_ts == content_ts:
                 return bookmark
         return None
 
@@ -141,19 +141,19 @@ class SlackRepository:
 
     def update_bookmark(
         self,
-        content_id: str,
+        content_ts: str,
         new_note: str = "",
         new_status: models.BookmarkStatusEnum = models.BookmarkStatusEnum.ACTIVE,
     ) -> None:
         """북마크를 업데이트합니다."""
-        df = pd.read_csv("store/bookmark.csv")
+        df = pd.read_csv("store/bookmark.csv", dtype=str, na_filter=False)
 
         if new_note:
-            df.loc[df["content_id"] == content_id, "note"] = new_note
+            df.loc[df["content_ts"] == content_ts, "note"] = new_note
         if new_status:
-            df.loc[df["content_id"] == content_id, "status"] = new_status
+            df.loc[df["content_ts"] == content_ts, "status"] = new_status
         if new_note or new_status:
-            df.loc[df["content_id"] == content_id, "updated_at"] = tz_now_to_str()
+            df.loc[df["content_ts"] == content_ts, "updated_at"] = tz_now_to_str()
 
         df.to_csv("store/bookmark.csv", index=False, quoting=csv.QUOTE_ALL)
 
@@ -163,7 +163,7 @@ class SlackRepository:
         new_intro: str,
     ) -> None:
         """유저 정보를 업데이트합니다."""
-        df = pd.read_csv("store/users.csv")
+        df = pd.read_csv("store/users.csv", dtype=str, na_filter=False)
         df.loc[df["user_id"] == user_id, "intro"] = new_intro
         df.to_csv("store/users.csv", index=False, quoting=csv.QUOTE_ALL)
 

--- a/app/slack/services.py
+++ b/app/slack/services.py
@@ -191,17 +191,26 @@ class SlackService:
             raise ValueError("노션은 하단의 '글 제목'을 필수로 입력해주세요.")
 
     def create_bookmark(
-        self, user_id: str, content_id: str, note: str = ""
+        self,
+        user_id: str,
+        author_user_id: str,
+        content_ts: str,
+        note: str = "",
     ) -> models.Bookmark:
         """북마크를 생성합니다."""
-        bookmark = models.Bookmark(user_id=user_id, content_id=content_id, note=note)
+        bookmark = models.Bookmark(
+            user_id=user_id,
+            author_user_id=author_user_id,
+            content_ts=content_ts,
+            note=note,
+        )
         self._repo.create_bookmark(bookmark)
         store.bookmark_upload_queue.append(bookmark.to_list_for_sheet())
         return bookmark
 
-    def get_bookmark(self, user_id: str, content_id: str) -> models.Bookmark | None:
+    def get_bookmark(self, user_id: str, content_ts: str) -> models.Bookmark | None:
         """북마크를 가져옵니다."""
-        bookmark = self._repo.get_bookmark(user_id, content_id)
+        bookmark = self._repo.get_bookmark(user_id, content_ts)
         return bookmark
 
     def fetch_bookmarks(self, user_id: str) -> list[models.Bookmark]:
@@ -218,19 +227,19 @@ class SlackService:
             contents = self._repo.fetch_contents_by_keyword(keyword)
         else:
             contents = self._repo.fetch_contents()
-        return [content for content in contents if content.content_id in content_ids]
+        return [content for content in contents if content.ts in content_ids]
 
     def update_bookmark(
         self,
         user_id: str,
-        content_id: str,
+        content_ts: str,
         new_note: str = "",
         new_status: models.BookmarkStatusEnum = models.BookmarkStatusEnum.ACTIVE,
     ) -> None:
         """북마크를 업데이트합니다."""
         # TODO: 북마크 삭제와 수정 분리할 것
-        self._repo.update_bookmark(content_id, new_note, new_status)
-        bookmark = self._repo.get_bookmark(user_id, content_id, status=new_status)
+        self._repo.update_bookmark(content_ts, new_note, new_status)
+        bookmark = self._repo.get_bookmark(user_id, content_ts, status=new_status)
         if bookmark:
             store.bookmark_update_queue.append(bookmark)
 

--- a/app/slack/services.py
+++ b/app/slack/services.py
@@ -193,14 +193,14 @@ class SlackService:
     def create_bookmark(
         self,
         user_id: str,
-        author_user_id: str,
+        content_user_id: str,
         content_ts: str,
         note: str = "",
     ) -> models.Bookmark:
         """북마크를 생성합니다."""
         bookmark = models.Bookmark(
             user_id=user_id,
-            author_user_id=author_user_id,
+            content_user_id=content_user_id,
             content_ts=content_ts,
             note=note,
         )
@@ -257,8 +257,22 @@ class SlackService:
         users = [models.User(**user) for user in self._repo._fetch_users()]
         return users
 
-    def get_content_by_ts(self, ts: str) -> models.Content:
-        return self._repo.get_content_by_ts(ts)  # type: ignore
+    def get_content_by(
+        self,
+        *,
+        ts: str | None = None,
+        user_id: str | None = None,
+        dt: str | None = None,
+    ) -> models.Content:
+        content = self._repo.get_content_by(
+            ts=ts,
+            user_id=user_id,
+            dt=dt,
+        )
+        if not content:
+            raise BotException("해당 콘텐츠 정보가 없어요.")
+
+        return content
 
     def create_coffee_chat_proof(
         self,

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,6 @@
 import csv
+from typing import Any
+import orjson
 import regex as re
 import datetime
 
@@ -68,3 +70,13 @@ def convert_user_id_to_name(message: str) -> str:
         message = message.replace(f"<@{user_id}>", name)
 
     return message
+
+
+def dict_to_json_str(data: dict[str, Any]) -> str:
+    """dict를 json string으로 변환합니다."""
+    return orjson.dumps(data).decode("utf-8")
+
+
+def json_str_to_dict(data: str) -> dict[str, Any]:
+    """json string을 dict로 변환합니다."""
+    return orjson.loads(data)


### PR DESCRIPTION
대시보드 팀(CRM) 의 요청으로 bookmark row 의 content fk 를 content_id 에서 content_ts 로 변경합니다.

slack 에서는 ts 를 메시지의 id 로 관리하고 대시보드 팀(CRM) 에서도 ts 로 row 를 핸들링하는 것이 수월하기 때문입니다.