### PR TITLE
feat: 리액션 추가 이벤트 수집

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -27,6 +27,7 @@ class SpreadSheetClient:
                 "backup": self._doc.worksheet("backup"),
                 "bookmark": self._doc.worksheet("bookmark"),
                 "coffee_chat_proof": self._doc.worksheet("coffee_chat_proof"),
+                "reactions": self._doc.worksheet("reactions"),
             }
             if not sheets
             else sheets

--- a/app/models.py
+++ b/app/models.py
@@ -312,3 +312,38 @@ class CoffeeChatProof(StoreModel):
             self.image_urls,
             self.selected_user_ids,
         ]
+
+
+class Reaction(StoreModel):
+    type: str
+    user_id: str
+    reaction: str
+    reaction_ts: str
+    item_type: str
+    item_user_id: str
+    item_channel: str
+    item_ts: str
+
+    def to_list_for_csv(self) -> list[str]:
+        return [
+            self.type,
+            self.user_id,
+            self.reaction,
+            self.reaction_ts,
+            self.item_type,
+            self.item_user_id,
+            self.item_channel,
+            self.item_ts,
+        ]
+
+    def to_list_for_sheet(self) -> list[str]:
+        return [
+            self.type,
+            self.user_id,
+            self.reaction,
+            self.reaction_ts,
+            self.item_type,
+            self.item_user_id,
+            self.item_channel,
+            self.item_ts,
+        ]

--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -277,5 +277,5 @@ event_descriptions = {
     "submit_coffee_chat_proof_button": "커피챗 인증 제출 시작",
     "submit_coffee_chat_proof_view": "커피챗 인증 제출 완료",
     "reaction_added": "리액션 추가",
-    "reaction_removed": "리액션 제거",
+    "reaction_removed": "리액션 삭제",
 }

--- a/app/slack/events/community.py
+++ b/app/slack/events/community.py
@@ -7,6 +7,7 @@ from app.slack.services import SlackService
 from app.slack.types import (
     ActionBodyType,
     MessageBodyType,
+    ReactionBodyType,
     ViewBodyType,
 )
 from slack_bolt.async_app import AsyncAck, AsyncSay
@@ -223,3 +224,34 @@ async def submit_coffee_chat_proof_view(
         },
         timeout=5.0,
     )
+
+
+async def handle_reaction_added(
+    ack: AsyncAck,
+    body: ReactionBodyType,
+    user: User,
+    service: SlackService,
+) -> None:
+    """리액션 추가 이벤트를 처리합니다."""
+    await ack()
+
+    service.create_reaction(
+        type=body["event"]["type"],
+        user_id=body["event"]["user"],
+        reaction=body["event"]["reaction"],
+        reaction_ts=body["event"]["event_ts"],
+        item_type=body["event"]["item"]["type"],
+        item_user_id=body["event"]["item_user"],
+        item_channel=body["event"]["item"]["channel"],
+        item_ts=body["event"]["item"]["ts"],
+    )
+
+
+async def handle_reaction_removed(
+    ack: AsyncAck,
+    body: ReactionBodyType,
+    user: User,
+    service: SlackService,
+):
+    """리액션 삭제 이벤트를 처리합니다."""
+    await ack()

--- a/app/slack/repositories.py
+++ b/app/slack/repositories.py
@@ -230,6 +230,6 @@ class SlackRepository:
 
     def create_reaction(self, reaction: models.Reaction) -> None:
         """리액션을 생성합니다."""
-        with open("store/reaction.csv", "a", newline="", encoding="utf-8") as f:
+        with open("store/reactions.csv", "a", newline="", encoding="utf-8") as f:
             writer = csv.writer(f, quoting=csv.QUOTE_ALL)
             writer.writerow(reaction.to_list_for_csv())

--- a/app/slack/repositories.py
+++ b/app/slack/repositories.py
@@ -227,3 +227,9 @@ class SlackRepository:
             return []
 
         return [models.CoffeeChatProof(**row) for row in df.to_dict(orient="records")]
+
+    def create_reaction(self, reaction: models.Reaction) -> None:
+        """리액션을 생성합니다."""
+        with open("store/reaction.csv", "a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f, quoting=csv.QUOTE_ALL)
+            writer.writerow(reaction.to_list_for_csv())

--- a/app/slack/services.py
+++ b/app/slack/services.py
@@ -323,8 +323,34 @@ class SlackService:
             if proof.user_id == user_id:
                 raise BotException("이미 답글로 커피챗을 인증했어요.")
 
+    def create_reaction(
+        self,
+        type: str,
+        user_id: str,
+        reaction: str,
+        reaction_ts: str,
+        item_type: str,
+        item_user_id: str,
+        item_channel: str,
+        item_ts: str,
+    ) -> models.Reaction:
+        """리액션을 생성합니다."""
+        reaction_model = models.Reaction(
+            type=type,
+            user_id=user_id,
+            reaction=reaction,
+            reaction_ts=reaction_ts,
+            item_type=item_type,
+            item_user_id=item_user_id,
+            item_channel=item_channel,
+            item_ts=item_ts,
+        )
+        self._repo.create_reaction(reaction_model)
+        store.reaction_upload_queue.append(reaction_model.to_list_for_sheet())
+        return reaction_model
 
-class SlackReminderService:
+
+class BackgroundService:
     def __init__(self, repo: SlackRepository) -> None:
         self._repo = repo
 

--- a/app/slack/types.py
+++ b/app/slack/types.py
@@ -213,3 +213,33 @@ class MessageBodyType(TypedDict):
     authorizations: list[Authorization]
     is_ext_shared_channel: bool
     event_context: str
+
+
+class ReactionEventItem(TypedDict):
+    type: str
+    channel: str
+    ts: str
+
+
+class ReactionEvent(TypedDict):
+    user: str
+    type: str
+    reaction: str
+    item: ReactionEventItem
+    item_user: str
+    event_ts: str
+
+
+class ReactionBodyType(TypedDict):
+    token: str
+    team_id: str
+    context_team_id: str
+    context_enterprise_id: str | None
+    api_app_id: str
+    event: ReactionEvent
+    type: str
+    event_id: str
+    event_time: int
+    authorizations: list[Authorization]
+    is_ext_shared_channel: bool
+    event_context: str

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app.slack.repositories import SlackRepository
-from app.slack.services import SlackReminderService
+from app.slack.services import BackgroundService
 
 
 @pytest.fixture
@@ -10,8 +10,8 @@ def slack_repo() -> SlackRepository:
 
 
 @pytest.fixture
-def slack_remind_service(slack_repo: SlackRepository) -> SlackReminderService:
-    return SlackReminderService(slack_repo)
+def background_service(slack_repo: SlackRepository) -> BackgroundService:
+    return BackgroundService(slack_repo)
 
 
 class FakeAsyncWebClient:

--- a/test/test_reminder.py
+++ b/test/test_reminder.py
@@ -7,14 +7,14 @@ import pytest
 from pytest_mock import MockerFixture
 from app.models import Content, User
 from app.slack.repositories import SlackRepository
-from app.slack.services import SlackReminderService
+from app.slack.services import BackgroundService
 from app.utils import tz_now
 from test.conftest import FakeSlackApp
 
 
 @pytest.mark.asyncio
 async def test_send_reminder_message_to_user(
-    slack_remind_service: SlackReminderService,
+    background_service: BackgroundService,
     slack_app: FakeSlackApp,
     mocker: MockerFixture,
 ) -> None:
@@ -86,7 +86,9 @@ async def test_send_reminder_message_to_user(
                 intro="안녕하세요. 도진홍입니다.",
                 contents=[
                     Content(  # 지난 회차 제출한 경우
-                        dt=(tz_now() - timedelta(days=15)).strftime("%Y-%m-%d %H:%M:%S"),
+                        dt=(tz_now() - timedelta(days=15)).strftime(
+                            "%Y-%m-%d %H:%M:%S"
+                        ),
                         user_id="리마인드 대상2",
                         username="도진홍",
                         type="submit",
@@ -99,7 +101,7 @@ async def test_send_reminder_message_to_user(
     slack_client_mock = mocker.patch.object(slack_app.client, "chat_postMessage")
 
     # when
-    await slack_remind_service.send_reminder_message_to_user(cast(AsyncApp, slack_app))
+    await background_service.send_reminder_message_to_user(cast(AsyncApp, slack_app))
 
     # then
     assert slack_client_mock.call_count == 2


### PR DESCRIPTION
대시보드(CRM) 팀의 요청에 따라 리액션 추가 이벤트를 수집합니다.

추가로, 스케줄러와 서버 셧다운 시의 로직을 보완합니다.