### PR TITLE
feat: 관리자용 채널 초대 기능 구현

### DIFF
--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -22,7 +22,12 @@ from app.slack.repositories import SlackRepository
 from app.slack.services import SlackService
 from app.slack.types import MessageBodyType
 
-app = AsyncApp(token=settings.SLACK_BOT_TOKEN)
+app = AsyncApp(
+    client=AsyncWebClient(
+        token=settings.SLACK_BOT_TOKEN,
+        timeout=10,
+    ),
+)
 
 
 @app.middleware
@@ -242,9 +247,11 @@ app.view("handle_bookmark_page_view")(contents_events.handle_bookmark_page)
 app.event("app_mention")(core_events.handle_app_mention)
 app.command("/예치금")(core_events.deposit_command)
 app.command("/제출내역")(core_events.history_command)
-app.command("/관리자")(core_events.admin_command)
 app.command("/도움말")(core_events.help_command)
-
+app.command("/관리자")(core_events.admin_command)
+app.action("sync_store")(core_events.handle_sync_store)
+app.action("invite_channel")(core_events.handle_invite_channel)
+app.view("invite_channel_view")(core_events.handle_invite_channel_view)
 
 event_descriptions = {
     "/제출": "글 제출 시작",
@@ -278,4 +285,6 @@ event_descriptions = {
     "submit_coffee_chat_proof_view": "커피챗 인증 제출 완료",
     "reaction_added": "리액션 추가",
     "reaction_removed": "리액션 삭제",
+    "sync_store": "데이터 동기화",
+    "invite_channel": "채널 초대",
 }

--- a/app/slack/events/community.py
+++ b/app/slack/events/community.py
@@ -77,18 +77,13 @@ async def handle_coffee_chat_message(
                     ButtonElement(
                         text="안내 닫기",
                         action_id="cancel_coffee_chat_proof_button",
-                        style="danger",
-                    )
-                ]
-            ),
-            ActionsBlock(
-                elements=[
+                    ),
                     ButtonElement(
                         text="커피챗 인증",
                         action_id="submit_coffee_chat_proof_button",
                         value=body["event"]["ts"],
                         style="primary",
-                    )
+                    ),
                 ]
             ),
         ],

--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -1,15 +1,32 @@
+import tenacity
+
 from app.client import SpreadSheetClient
 from app.config import settings
 from app.constants import HELP_TEXT
 from app.models import User
 from app.slack.services import SlackService
-from app.slack.types import AppMentionBodyType, CommandBodyType
+from app.slack.types import (
+    ActionBodyType,
+    AppMentionBodyType,
+    CommandBodyType,
+    ViewBodyType,
+    ViewType,
+)
 from app.store import Store
 
-from slack_sdk.models.blocks import SectionBlock, DividerBlock
+from slack_sdk.models.blocks import (
+    SectionBlock,
+    DividerBlock,
+    ActionsBlock,
+    ButtonElement,
+    ChannelMultiSelectElement,
+    UserSelectElement,
+    InputBlock,
+)
 from slack_sdk.models.views import View
 from slack_bolt.async_app import AsyncAck, AsyncSay
 from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.errors import SlackApiError
 
 
 async def handle_app_mention(
@@ -86,37 +103,6 @@ async def history_command(
     )
 
 
-async def admin_command(
-    ack: AsyncAck,
-    body: CommandBodyType,
-    say: AsyncSay,
-    client: AsyncWebClient,
-    user: User,
-    service: SlackService,
-) -> None:
-    """관리자 메뉴를 조회합니다."""
-    await ack()
-    # TODO: 추후 관리자 메뉴 추가
-
-    if user.user_id not in settings.ADMIN_IDS:
-        raise PermissionError("`/관리자` 명령어는 관리자만 호출할 수 있어요. 🤭")
-    try:
-        await client.chat_postMessage(
-            channel=settings.ADMIN_CHANNEL, text="store pull 시작"
-        )
-        sheet_client = SpreadSheetClient()
-        store = Store(client=sheet_client)
-        store.bulk_upload("logs")
-        store.backup("contents")
-        store.initialize_logs()
-        store.pull()
-        await client.chat_postMessage(
-            channel=settings.ADMIN_CHANNEL, text="store pull 완료"
-        )
-    except Exception as e:
-        await client.chat_postMessage(channel=settings.ADMIN_CHANNEL, text=str(e))
-
-
 async def help_command(
     ack: AsyncAck,
     body: CommandBodyType,
@@ -134,3 +120,197 @@ async def help_command(
         user=user.user_id,
         text=HELP_TEXT,
     )
+
+
+async def admin_command(
+    ack: AsyncAck,
+    body: CommandBodyType,
+    say: AsyncSay,
+    client: AsyncWebClient,
+    user: User,
+    service: SlackService,
+) -> None:
+    """관리자 메뉴를 조회합니다."""
+    await ack()
+
+    if user.user_id not in settings.ADMIN_IDS:
+        raise PermissionError("`/관리자` 명령어는 관리자만 호출할 수 있어요. 🤭")
+
+    text = "관리자 메뉴입니다."
+    await client.chat_postEphemeral(
+        channel=body["channel_id"],
+        user=user.user_id,
+        text=text,
+        blocks=[
+            SectionBlock(text=text),
+            ActionsBlock(
+                elements=[
+                    ButtonElement(
+                        text="데이터 동기화",
+                        action_id="sync_store",
+                        value="sync_store",
+                    ),
+                    ButtonElement(
+                        text="채널 초대",
+                        action_id="invite_channel",
+                        value="invite_channel",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+async def handle_sync_store(
+    ack: AsyncAck,
+    body: ActionBodyType,
+    say: AsyncSay,
+    client: AsyncWebClient,
+    user: User,
+    service: SlackService,
+) -> None:
+    """데이터 동기화를 수행합니다."""
+    await ack()
+
+    try:
+        await client.chat_postMessage(
+            channel=settings.ADMIN_CHANNEL, text="데이터 동기화 시작"
+        )
+        sheet_client = SpreadSheetClient()
+        store = Store(client=sheet_client)
+        store.bulk_upload("logs")
+        store.backup("contents")
+        store.initialize_logs()
+        store.pull()
+
+        await client.chat_postMessage(
+            channel=settings.ADMIN_CHANNEL, text="데이터 동기화 완료"
+        )
+
+    except Exception as e:
+        await client.chat_postMessage(channel=settings.ADMIN_CHANNEL, text=str(e))
+
+
+async def handle_invite_channel(
+    ack: AsyncAck,
+    body: ActionBodyType,
+    say: AsyncSay,
+    client: AsyncWebClient,
+    user: User,
+    service: SlackService,
+) -> None:
+    """채널 초대를 수행합니다."""
+    await ack()
+
+    await client.views_open(
+        trigger_id=body["trigger_id"],
+        view=View(
+            type="modal",
+            title="채널 초대",
+            submit="채널 초대하기",
+            callback_id="invite_channel_view",
+            close="닫기",
+            blocks=[
+                SectionBlock(
+                    text="초대하고 싶은 채널과 멤버를 선택해주세요.",
+                ),
+                InputBlock(
+                    block_id="user",
+                    label="멤버",
+                    optional=False,
+                    element=UserSelectElement(
+                        action_id="select_user",
+                        placeholder="멤버를 선택해주세요.",
+                    ),
+                ),
+                InputBlock(
+                    block_id="channel",
+                    label="채널",
+                    optional=True,
+                    element=ChannelMultiSelectElement(
+                        action_id="select_channels",
+                        placeholder="채널을 선택하지 않으면 모든 공개 채널에 초대합니다.",
+                    ),
+                ),
+            ],
+        ),
+    )
+
+
+async def handle_invite_channel_view(
+    ack: AsyncAck,
+    body: ViewBodyType,
+    client: AsyncWebClient,
+    view: ViewType,
+    say: AsyncSay,
+    user: User,
+    service: SlackService,
+) -> None:
+    """채널 초대를 수행합니다."""
+    await ack()
+
+    values = body["view"]["state"]["values"]
+    user_id = values["user"]["select_user"]["selected_user"]
+    channel_ids = values["channel"]["select_channels"]["selected_channels"]
+
+    if not channel_ids:
+        channel_ids = await _fetch_public_channel_ids(client)
+
+    await client.chat_postMessage(
+        channel=settings.ADMIN_CHANNEL,
+        text=f"<@{user_id}> 님의 채널 초대를 시작합니다.\n\n채널 수 : {len(channel_ids)} 개\n채널 아이디 : {channel_ids}\n",
+    )
+
+    for channel_id in channel_ids:
+        result = await _invite_channel(client, user_id, channel_id)
+        await client.chat_postMessage(
+            channel=settings.ADMIN_CHANNEL,
+            text=result,
+        )
+
+    await client.chat_postMessage(
+        channel=settings.ADMIN_CHANNEL,
+        text="채널 초대가 완료되었습니다.",
+    )
+
+
+@tenacity.retry(
+    stop=tenacity.stop_after_attempt(3),
+    wait=tenacity.wait_fixed(1),
+    reraise=True,
+)
+async def _fetch_public_channel_ids(client: AsyncWebClient) -> list[str]:
+    """모든 공개 채널의 아이디를 조회합니다."""
+    res = await client.conversations_list(limit=500, types="public_channel")
+    return [channel["id"] for channel in res["channels"]]
+
+
+@tenacity.retry(
+    stop=tenacity.stop_after_attempt(3),
+    wait=tenacity.wait_fixed(1),
+    reraise=True,
+)
+async def _invite_channel(
+    client: AsyncWebClient,
+    user_id: str,
+    channel_id: str,
+) -> str:
+    """채널에 멤버를 초대합니다."""
+    try:
+        await client.conversations_invite(channel=channel_id, users=user_id)
+        result = " -> ✅ (채널 초대)"
+    except SlackApiError as e:
+        # 봇이 채널에 없는 경우, 채널에 참여하고 초대합니다.
+        if e.response["error"] == "not_in_channel":
+            await client.conversations_join(channel=channel_id)
+            await client.conversations_invite(channel=channel_id, users=user_id)
+            result = " -> ✅ (또봇도 함께 채널 초대)"
+        elif e.response["error"] == "already_in_channel":
+            result = " -> ✅ (이미 채널에 참여 중)"
+        elif e.response["error"] == "cant_invite_self":
+            result = " -> ✅ (또봇이 자기 자신을 초대)"
+        else:
+            link = "<https://api.slack.com/methods/conversations.invite#errors|문서 확인하기>"
+            result = f" -> 😵 ({e.response['error']}) 👉 {link}"
+
+    return f"\n<#{channel_id}>" + result

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,6 +81,7 @@ slack-sdk==3.19.5
 sniffio==1.3.0
 soupsieve==2.4.1
 starlette==0.36.3
+tenacity==9.0.0
 termcolor==2.3.0
 tomli==2.0.1
 tqdm==4.65.0


### PR DESCRIPTION
글또 10기는 최소 600 명 이상이 신청할 것으로 예상됩니다.

그만큼 채널 수도 많아지므로 특정 멤버나 봇을 쉽게 추가하기 위하여 관리자용 [채널 초대] 기능을 구현합니다.

기존에는 일일히 수동으로 각각의 채널에 참여했다면 이를 봇을 통해 자동화 합니다.

