### PR TITLE
feat: 멤버가 종이비행기를 보내면 또봇이 인프런 쿠폰이 담긴 종이비행기를 보냅니다

### DIFF
--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -1,6 +1,11 @@
+import asyncio
 import csv
+import datetime
 import os
+from typing import TypedDict
+import zoneinfo
 import tenacity
+import pandas as pd
 
 from app.client import SpreadSheetClient
 from app.config import settings
@@ -40,7 +45,7 @@ from slack_bolt.async_app import AsyncAck, AsyncSay
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.errors import SlackApiError
 
-from app.utils import ts_to_dt
+from app.utils import ts_to_dt, tz_now
 
 
 async def handle_app_mention(
@@ -1018,7 +1023,7 @@ async def send_paper_plane_message_view(
 
     await client.chat_postMessage(
         channel=settings.THANKS_CHANNEL,
-        text=f"💌 *<@{receiver_id}>* 님에게 종이비행기가 도착했어요!😊",
+        text=f"💌 *<@{receiver_id}>* 님에게 종이비행기가 도착했어요!",
         blocks=[
             SectionBlock(
                 text=f"💌 *<@{receiver_id}>* 님에게 종이비행기가 도착했어요!\n\n",
@@ -1035,7 +1040,7 @@ async def send_paper_plane_message_view(
 
     await client.chat_postMessage(
         channel=user.user_id,
-        text=f"💌 *<@{receiver_id}>* 님에게 종이비행기를 보냈어요!😊",
+        text=f"💌 *<@{receiver_id}>* 님에게 종이비행기를 보냈어요!",
         blocks=[
             SectionBlock(
                 text=f"💌 *<@{receiver_id}>* 님에게 종이비행기를 보냈어요!\n\n",
@@ -1048,6 +1053,100 @@ async def send_paper_plane_message_view(
                 ],
             ),
         ],
+    )
+
+    # 인프런 쿠폰 지급 로직, 2024년 11월 10일 이후부터 지급됩니다.
+    coupon_issue_start_date = datetime.datetime(
+        2024, 11, 10, tzinfo=zoneinfo.ZoneInfo("Asia/Seoul")
+    ).date()
+    if tz_now().date() < coupon_issue_start_date:
+        # 인프런 쿠폰 지급 시작일 이전이라면 종이비행기를 보내지 않습니다.
+        return None
+
+    inflearn_coupon = get_inflearn_coupon(user_id=user.user_id)
+    if not inflearn_coupon:
+        # 인프런 쿠폰이 존재하지 않다면 관리자에게 알립니다.
+        await client.chat_postMessage(
+            channel=settings.ADMIN_CHANNEL,
+            text=f"💌 *<@{user.user_id}>* 님의 인프런 쿠폰이 존재하지 않아요.",
+        )
+        return None
+    elif inflearn_coupon["status"] == "received":
+        # 이미 쿠폰을 받았다면 종이비행기를 보내지 않습니다.
+        return None
+    else:
+        # 인프런 쿠폰을 받지 않았다면 할인쿠폰 코드와 함께 종이비행기를 보냅니다.
+        text = (
+            f"{inflearn_coupon['user_name'][1:]}님의 따뜻함이 글또를 더 따뜻하게 만들었어요. 이에 감사한 마음을 담아 [인프런 할인 쿠폰]을 보내드려요.\n\n"
+            "- 할인율 : 30%\n"
+            "- 사용 기한 : 2025. 3. 30. 23:59 까지\n"
+            f"- 쿠폰 코드 : **{inflearn_coupon['code']}**\n"
+            "- 쿠폰 등록 : 쿠폰 등록 하러가기\n\n"
+            "쿠폰 코드를 [할인쿠폰 코드 입력란]에 등록하면 사용할 수 있어요."
+        )
+
+        ttobot = service.get_user(user_id=settings.TTOBOT_USER_ID)
+        service.create_paper_plane(
+            sender=ttobot,
+            receiver=user,
+            text=text,
+        )
+
+        await asyncio.sleep(
+            5
+        )  # 종이비행기 메시지 전송 후 5초 뒤에 전송. 이유는 바로 전송할 경우 본인 전송 알림 메시지와 구분이 어려움.
+        await client.chat_postMessage(
+            channel=user.user_id,
+            text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 으로부터 종이비행기 선물이 도착했어요!🎁",
+            blocks=[
+                SectionBlock(
+                    text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 으로부터 종이비행기 선물이 도착했어요!🎁\n\n",
+                ),
+                ContextBlock(
+                    elements=[
+                        MarkdownTextObject(
+                            text=">받은 종이비행기는 `/종이비행기` 명령어 -> [주고받은 종이비행기 보기] 를 통해 확인할 수 있어요."
+                        )
+                    ],
+                ),
+            ],
+        )
+
+        update_inflearn_coupon_status(user_id=user.user_id, status="received")
+        return None
+
+
+class InflearnCoupon(TypedDict):
+    user_id: str
+    user_name: str
+    code: str
+    status: str
+
+
+def get_inflearn_coupon(user_id: str) -> InflearnCoupon | None:
+    """인프런 쿠폰 코드를 반환합니다."""
+    try:
+        df = pd.read_csv(
+            "store/_inflearn_coupon.csv", encoding="utf-8", quoting=csv.QUOTE_ALL
+        )
+    except FileNotFoundError:
+        return None
+
+    coupon_row = df[df["user_id"] == user_id]
+    if not coupon_row.empty:
+        return coupon_row.iloc[0].to_dict()
+    return None
+
+
+def update_inflearn_coupon_status(user_id: str, status: str) -> None:
+    """인프런 쿠폰 수령 상태를 업데이트합니다."""
+    df = pd.read_csv("store/_inflearn_coupon.csv", encoding="utf-8")
+    df.loc[df["user_id"] == user_id, "status"] = status
+    df.to_csv(
+        "store/_inflearn_coupon.csv",
+        index=False,
+        encoding="utf-8",
+        quoting=csv.QUOTE_ALL,
     )
 
 

--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -1109,23 +1109,31 @@ async def send_paper_plane_message_view(
         await asyncio.sleep(
             5
         )  # 종이비행기 메시지 전송 후 5초 뒤에 전송. 이유는 바로 전송할 경우 본인 전송 알림 메시지와 구분이 어려움.
-        await client.chat_postMessage(
-            channel=user.user_id,
-            text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 의 깜짝 선물이 담긴 종이비행기가 도착했어요!🎁",
-            blocks=[
-                SectionBlock(
-                    text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 의 깜짝 선물이 담긴 종이비행기가 도착했어요!🎁\n\n",
-                ),
-                ContextBlock(
-                    elements=[
-                        MarkdownTextObject(
-                            text=">받은 종이비행기는 `/종이비행기` 명령어 -> [주고받은 종이비행기 보기] 를 통해 확인할 수 있어요."
-                        )
-                    ],
-                ),
-            ],
-        )
-        return None
+
+        try:
+            await client.chat_postMessage(
+                channel=user.user_id,
+                text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 의 깜짝 선물이 담긴 종이비행기가 도착했어요!🎁",
+                blocks=[
+                    SectionBlock(
+                        text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 의 깜짝 선물이 담긴 종이비행기가 도착했어요!🎁\n\n",
+                    ),
+                    ContextBlock(
+                        elements=[
+                            MarkdownTextObject(
+                                text=">받은 종이비행기는 `/종이비행기` 명령어 -> [주고받은 종이비행기 보기] 를 통해 확인할 수 있어요."
+                            )
+                        ],
+                    ),
+                ],
+            )
+            return None
+        except Exception as e:
+            await client.chat_postMessage(
+                channel=settings.ADMIN_CHANNEL,
+                text=f"💌 *<@{user.user_id}>* 님에게 인프런 쿠폰을 보냈으나 메시지 전송에 실패했어요. {e}",
+            )
+            return None
 
 
 class InflearnCoupon(TypedDict):

--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -1,9 +1,7 @@
 import asyncio
 import csv
-import datetime
 import os
 from typing import TypedDict
-import zoneinfo
 import tenacity
 import pandas as pd
 
@@ -45,7 +43,7 @@ from slack_bolt.async_app import AsyncAck, AsyncSay
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.errors import SlackApiError
 
-from app.utils import ts_to_dt, tz_now
+from app.utils import ts_to_dt
 
 
 async def handle_app_mention(
@@ -999,6 +997,28 @@ async def send_paper_plane_message_view(
         )
         return
 
+    bot_ids = [
+        "U07PJ6J7FFV",
+        "U07P0BB4YKV",
+        "U07PFJCHHFF",
+        "U07PK8CLGKW",
+        "U07P8E69V3N",
+        "U07PB8HF4V8",
+        "U07PAMU09AS",
+        "U07PSF2PKKK",
+        "U07PK195U74",
+        "U04GVDM0R4Y",
+        "USLACKBOT",
+    ]
+    if receiver_id in bot_ids:
+        await ack(
+            response_action="errors",
+            errors={
+                "paper_plane_message": "봇에게 종이비행기를 보낼 수 없어요~😉",
+            },
+        )
+        return
+
     if user.user_id == settings.SUPER_ADMIN:
         pass
     else:
@@ -1055,14 +1075,7 @@ async def send_paper_plane_message_view(
         ],
     )
 
-    # 인프런 쿠폰 지급 로직, 2024년 11월 10일 이후부터 지급됩니다.
-    coupon_issue_start_date = datetime.datetime(
-        2024, 11, 10, tzinfo=zoneinfo.ZoneInfo("Asia/Seoul")
-    ).date()
-    if tz_now().date() < coupon_issue_start_date:
-        # 인프런 쿠폰 지급 시작일 이전이라면 종이비행기를 보내지 않습니다.
-        return None
-
+    # 인프런 쿠폰 지급 로직
     inflearn_coupon = get_inflearn_coupon(user_id=user.user_id)
     if not inflearn_coupon:
         # 인프런 쿠폰이 존재하지 않다면 관리자에게 알립니다.

--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -1104,16 +1104,17 @@ async def send_paper_plane_message_view(
             receiver=user,
             text=text,
         )
+        update_inflearn_coupon_status(user_id=user.user_id, status="received")
 
         await asyncio.sleep(
             5
         )  # 종이비행기 메시지 전송 후 5초 뒤에 전송. 이유는 바로 전송할 경우 본인 전송 알림 메시지와 구분이 어려움.
         await client.chat_postMessage(
             channel=user.user_id,
-            text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 으로부터 종이비행기 선물이 도착했어요!🎁",
+            text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 의 깜짝 선물이 담긴 종이비행기가 도착했어요!🎁",
             blocks=[
                 SectionBlock(
-                    text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 으로부터 종이비행기 선물이 도착했어요!🎁\n\n",
+                    text=f"💌 *<@{settings.TTOBOT_USER_ID}>* 의 깜짝 선물이 담긴 종이비행기가 도착했어요!🎁\n\n",
                 ),
                 ContextBlock(
                     elements=[
@@ -1124,8 +1125,6 @@ async def send_paper_plane_message_view(
                 ),
             ],
         )
-
-        update_inflearn_coupon_status(user_id=user.user_id, status="received")
         return None
 
 


### PR DESCRIPTION
### 요구사항

- 특정일 이후에 종이비행기를 보낸 멤버에게 또봇이 쿠폰이 담긴 종이비행기를 보낸다.
    - 또봇이 쿠폰이 담긴 종이비행기를 보낼 때, 그 전에 보낸 적이 있다면 보내지 않는다.
    - 보낸적이 없으면 멤버의 쿠폰번호를 가져와 종이비행기에 넣어 보낸다.
- 또봇이 보내는 종이비행기는 5초 후에 개인 디엠으로 알림이 간다.
    - 디엠으로 알림이 가는 이유는 공개채널로 갈 경우 종이비행기를 보낸 사람이 누군지 알게되기 때문이다.
    - 5초 후에 알림이 가는 이유는 멤버가 보낸 종이비행기 알림과 겹치지 않도록, 또봇의 종이비행기를 인지하기 쉽게하기 위함이다.
- 더 자세한 내용은 [노션 태스크](https://www.notion.so/zzsza/3fc8af34c7664cc288367331c2a57544)를 참고해주세요.
    
### 기타
- 배포 전에 쿠폰 정보가 담긴 _inflearn_coupon.csv 파일을 서버에 추가할 것.


### 결과
- 아래 이미지 처럼 표시됩니다.
![image](https://github.com/user-attachments/assets/401fa707-8867-4220-b810-401cf492a0bc)
