### PR TITLE
feat: 멤버 글을 받아볼 수 있는 멤버 구독 기능을 추가합니다.

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -29,6 +29,7 @@ class SpreadSheetClient:
                 "coffee_chat_proof": self._doc.worksheet("coffee_chat_proof"),
                 "point_histories": self._doc.worksheet("point_histories"),
                 "paper_plane": self._doc.worksheet("paper_plane"),
+                "subscriptions": self._doc.worksheet("subscriptions"),
             }
             if not sheets
             else sheets

--- a/app/constants.py
+++ b/app/constants.py
@@ -86,3 +86,18 @@ PRIMARY_CHANNEL = [
     "C05J87UPC3F",  # dev 채널 1 (로컬 테스트 채널)
     "C07PD0VMHJM",  # dev 채널 2 (또봇 크루 채널)
 ]
+
+
+BOT_IDS = [
+    "U07PJ6J7FFV",
+    "U07P0BB4YKV",
+    "U07PFJCHHFF",
+    "U07PK8CLGKW",
+    "U07P8E69V3N",
+    "U07PB8HF4V8",
+    "U07PAMU09AS",
+    "U07PSF2PKKK",
+    "U07PK195U74",
+    "U04GVDM0R4Y",
+    "USLACKBOT",
+]

--- a/app/models.py
+++ b/app/models.py
@@ -483,6 +483,7 @@ class Subscription(StoreModel):
     id: str = Field(default_factory=generate_unique_id)
     user_id: str
     target_user_id: str
+    target_user_channel: str
     status: SubscriptionStatusEnum = SubscriptionStatusEnum.ACTIVE
     created_at: str = Field(default_factory=tz_now_to_str)
     updated_at: str = ""
@@ -492,6 +493,7 @@ class Subscription(StoreModel):
             self.id,
             self.user_id,
             self.target_user_id,
+            self.target_user_channel,
             self.status,
             self.created_at,
             self.updated_at,
@@ -502,6 +504,7 @@ class Subscription(StoreModel):
             self.id,
             self.user_id,
             self.target_user_id,
+            self.target_user_channel,
             self.status,
             self.created_at,
             self.updated_at,

--- a/app/models.py
+++ b/app/models.py
@@ -472,3 +472,37 @@ class PaperPlane(StoreModel):
             self.color_label,
             self.created_at,
         ]
+
+
+class SubscriptionStatusEnum(str, Enum):
+    ACTIVE = "ACTIVE"
+    DELETED = "DELETED"
+
+
+class Subscription(StoreModel):
+    id: str = Field(default_factory=generate_unique_id)
+    user_id: str
+    target_user_id: str
+    status: SubscriptionStatusEnum = SubscriptionStatusEnum.ACTIVE
+    created_at: str = Field(default_factory=tz_now_to_str)
+    updated_at: str = ""
+
+    def to_list_for_sheet(self) -> list[str]:
+        return [
+            self.id,
+            self.user_id,
+            self.target_user_id,
+            self.status,
+            self.created_at,
+            self.updated_at,
+        ]
+
+    def to_list_for_csv(self) -> list[str]:
+        return [
+            self.id,
+            self.user_id,
+            self.target_user_id,
+            self.status,
+            self.created_at,
+            self.updated_at,
+        ]

--- a/app/models.py
+++ b/app/models.py
@@ -476,7 +476,7 @@ class PaperPlane(StoreModel):
 
 class SubscriptionStatusEnum(str, Enum):
     ACTIVE = "ACTIVE"
-    DELETED = "DELETED"
+    CANCELED = "CANCELED"
 
 
 class Subscription(StoreModel):

--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -414,4 +414,5 @@ event_descriptions = {
     "subscribe_member_by_action": "멤버 구독 액션 모달",
     "subscribe_member_by_view": "멤버 구독 뷰 모달",
     "handle_subscribe_member_view": "멤버 구독 완료",
+    "open_subscription_permalink": "구독 링크 열기",
 }

--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -18,6 +18,7 @@ from app.slack.events import community as community_events
 from app.slack.events import contents as contents_events
 from app.slack.events import core as core_events
 from app.slack.events import log as log_events
+from app.slack.events import subscriptions as subscriptions_events
 from app.exception import BotException
 from app.slack.repositories import SlackRepository
 from app.slack.services.base import SlackService
@@ -347,7 +348,15 @@ app.action("open_coffee_chat_history_view")(core_events.open_coffee_chat_history
 app.action("download_point_history")(core_events.download_point_history)
 app.action("download_coffee_chat_history")(core_events.download_coffee_chat_history)
 app.action("download_submission_history")(core_events.download_submission_history)
-
+app.action("subscribe_member_content_by_action")(
+    subscriptions_events.subscribe_member_content_by_action
+)
+app.view("subscribe_member_content_by_view")(
+    subscriptions_events.subscribe_member_content_by_view
+)
+app.view("handle_subscribe_member_content_view")(
+    subscriptions_events.handle_subscribe_member_content_view
+)
 
 # log
 app.event("reaction_added")(log_events.handle_reaction_added)
@@ -403,4 +412,7 @@ event_descriptions = {
     "send_paper_plane_message_view": "종이비행기 메시지 전송 완료",
     "channel_created": "채널 생성",
     "/종이비행기": "종이비행기 모달 열기",
+    "subscribe_member_content_by_action": "멤버 구독 액션 모달",
+    "subscribe_member_content_by_view": "멤버 구독 뷰 모달",
+    "handle_subscribe_member_content_view": "멤버 구독 완료",
 }

--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -392,7 +392,7 @@ event_descriptions = {
     "cancel_coffee_chat_proof_button": "커피챗 인증 안내 닫기",
     "submit_coffee_chat_proof_button": "커피챗 인증 제출 시작",
     "submit_coffee_chat_proof_view": "커피챗 인증 제출 완료",
-    "sync_store": "데이터 동기화",
+    "sync_store_select": "데이터 동기화",
     "invite_channel": "채널 초대",
     "invite_channel_view": "채널 초대 완료",
     "app_home_opened": "홈 탭 열림",
@@ -415,4 +415,5 @@ event_descriptions = {
     "subscribe_member_by_view": "멤버 구독 뷰 모달",
     "handle_subscribe_member_view": "멤버 구독 완료",
     "open_subscription_permalink": "구독 링크 열기",
+    "unsubscribe_target_user": "멤버 구독 취소",
 }

--- a/app/slack/event_handler.py
+++ b/app/slack/event_handler.py
@@ -348,15 +348,14 @@ app.action("open_coffee_chat_history_view")(core_events.open_coffee_chat_history
 app.action("download_point_history")(core_events.download_point_history)
 app.action("download_coffee_chat_history")(core_events.download_coffee_chat_history)
 app.action("download_submission_history")(core_events.download_submission_history)
-app.action("subscribe_member_content_by_action")(
-    subscriptions_events.subscribe_member_content_by_action
+app.action("subscribe_member_by_action")(
+    subscriptions_events.subscribe_member_by_action
 )
-app.view("subscribe_member_content_by_view")(
-    subscriptions_events.subscribe_member_content_by_view
+app.view("subscribe_member_by_view")(subscriptions_events.subscribe_member_by_view)
+app.view("handle_subscribe_member_view")(
+    subscriptions_events.handle_subscribe_member_view
 )
-app.view("handle_subscribe_member_content_view")(
-    subscriptions_events.handle_subscribe_member_content_view
-)
+app.action("unsubscribe_target_user")(subscriptions_events.unsubscribe_target_user)
 
 # log
 app.event("reaction_added")(log_events.handle_reaction_added)
@@ -412,7 +411,7 @@ event_descriptions = {
     "send_paper_plane_message_view": "종이비행기 메시지 전송 완료",
     "channel_created": "채널 생성",
     "/종이비행기": "종이비행기 모달 열기",
-    "subscribe_member_content_by_action": "멤버 구독 액션 모달",
-    "subscribe_member_content_by_view": "멤버 구독 뷰 모달",
-    "handle_subscribe_member_content_view": "멤버 구독 완료",
+    "subscribe_member_by_action": "멤버 구독 액션 모달",
+    "subscribe_member_by_view": "멤버 구독 뷰 모달",
+    "handle_subscribe_member_view": "멤버 구독 완료",
 }

--- a/app/slack/events/community.py
+++ b/app/slack/events/community.py
@@ -309,7 +309,6 @@ async def paper_plane_command(
                         ButtonElement(
                             text="종이비행기 보내기",
                             action_id="send_paper_plane_message",
-                            value="send_paper_plane_message",
                             style="primary",
                         ),
                         ButtonElement(

--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -714,8 +714,8 @@ async def handle_home_tab(
                     elements=[
                         ButtonElement(
                             text="멤버 구독하기",
-                            action_id="subscribe_member_content_by_action",
-                            value="subscribe_member_content_by_action",
+                            action_id="subscribe_member_by_action",
+                            value="subscribe_member_by_action",
                             style="primary",
                         ),
                     ]

--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -968,7 +968,7 @@ async def send_paper_plane_message(
         ],
     )
 
-    callback_id = body["view"]["callback_id"]
+    callback_id = body.get("view", {}).get("callback_id")
     if callback_id == "paper_plane_command":
         # callback_id 가 있다면 모달에서 발생한 액션이므로 기존 모달을 업데이트합니다.
         await client.views_update(

--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from app.client import SpreadSheetClient
 from app.config import settings
+from app.constants import BOT_IDS
 from app.models import CoffeeChatProof, Content, PointHistory, User
 from app.slack.services.base import SlackService
 from app.slack.services.point import PointMap, PointService
@@ -704,9 +705,20 @@ async def handle_home_tab(
                     elements=[
                         TextObject(
                             type="mrkdwn",
-                            text="새로운 기능을 만나보세요. 더 나은 또봇을 위해 여러분의 의견을 기다립니다.\n\nComing Soon...🙇‍♂️",
+                            text="또봇의 새로운 기능들을 가장 먼저 만나보세요. 🤗\n"
+                            f"버그 제보와 아이디어 제안은 <#{settings.BOT_SUPPORT_CHANNEL}> 채널로 부탁드려요. 🙏",
                         ),
                     ],
+                ),
+                ActionsBlock(
+                    elements=[
+                        ButtonElement(
+                            text="멤버 구독하기",
+                            action_id="subscribe_member_content_by_action",
+                            value="subscribe_member_content_by_action",
+                            style="primary",
+                        ),
+                    ]
                 ),
             ],
         ),
@@ -1003,24 +1015,11 @@ async def send_paper_plane_message_view(
         )
         return
 
-    bot_ids = [
-        "U07PJ6J7FFV",
-        "U07P0BB4YKV",
-        "U07PFJCHHFF",
-        "U07PK8CLGKW",
-        "U07P8E69V3N",
-        "U07PB8HF4V8",
-        "U07PAMU09AS",
-        "U07PSF2PKKK",
-        "U07PK195U74",
-        "U04GVDM0R4Y",
-        "USLACKBOT",
-    ]
-    if receiver_id in bot_ids:
+    if receiver_id in BOT_IDS:
         await ack(
             response_action="errors",
             errors={
-                "paper_plane_message": "봇에게 종이비행기를 보낼 수 없어요~😉",
+                "paper_plane_message": "봇에게 종이비행기를 보낼 수 없어요. 😉",
             },
         )
         return

--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -337,6 +337,7 @@ async def admin_command(
                             Option(text="커피챗 인증", value="커피챗 인증"),
                             Option(text="포인트 히스토리", value="포인트 히스토리"),
                             Option(text="종이비행기", value="종이비행기"),
+                            Option(text="구독", value="구독"),
                         ],
                     ),
                 ],
@@ -393,6 +394,8 @@ async def handle_sync_store(
             store.pull_point_histories()
         elif value == "종이비행기":
             store.pull_paper_plane()
+        elif value == "구독":
+            store.pull_subscriptions()
         else:
             await client.chat_postMessage(
                 channel=settings.ADMIN_CHANNEL,

--- a/app/slack/events/core.py
+++ b/app/slack/events/core.py
@@ -640,7 +640,6 @@ async def handle_home_tab(
                         ButtonElement(
                             text="종이비행기 보내기",
                             action_id="send_paper_plane_message",
-                            value="send_paper_plane_message",
                             style="primary",
                         ),
                         ButtonElement(
@@ -929,6 +928,7 @@ async def send_paper_plane_message(
     """종이비행기 메시지를 전송합니다."""
     await ack()
 
+    initial_user_id = body["actions"][0].get("value")
     view = View(
         type="modal",
         title="종이비행기 보내기",
@@ -953,6 +953,7 @@ async def send_paper_plane_message(
                 element=UserSelectElement(
                     action_id="select_user",
                     placeholder="받는 사람을 선택해주세요.",
+                    initial_user=initial_user_id,
                 ),
             ),
             InputBlock(
@@ -1001,7 +1002,7 @@ async def send_paper_plane_message_view(
         await ack(
             response_action="errors",
             errors={
-                "paper_plane_receiver": "종이비행기는 자신에게 보낼 수 없어요~😉",
+                "paper_plane_receiver": "종이비행기는 자신에게 보낼 수 없어요. 😉",
             },
         )
         return
@@ -1010,7 +1011,7 @@ async def send_paper_plane_message_view(
         await ack(
             response_action="errors",
             errors={
-                "paper_plane_message": "종이비행기 메시지는 300자 이내로 작성해주세요.",
+                "paper_plane_message": "종이비행기 메시지는 300자 이내로 작성해주세요. 😉",
             },
         )
         return

--- a/app/slack/events/subscriptions.py
+++ b/app/slack/events/subscriptions.py
@@ -160,9 +160,22 @@ async def handle_subscribe_member_view(
         )
         return
 
+    target_user = service.get_only_user(target_user_id)
+    if not target_user:
+        await ack(
+            response_action="errors",
+            errors={"select_target_user": "구독할 멤버를 찾을 수 없습니다. 😅"},
+        )
+        return
+
+    # TODO: 이미 구독했다면 할 수 없습니다.
     await ack()
 
-    service.create_subscription(user_id=user.user_id, target_user_id=target_user_id)
+    service.create_subscription(
+        user_id=user.user_id,
+        target_user_id=target_user_id,
+        target_user_channel=target_user.channel_id,
+    )
 
     await client.views_open(
         trigger_id=body["trigger_id"],
@@ -219,3 +232,15 @@ async def unsubscribe_target_user(
             close="닫기",
         ),
     )
+
+
+async def open_subscription_permalink(
+    ack: AsyncAck,
+    body: ActionBodyType,
+    say: AsyncSay,
+    client: AsyncWebClient,
+    user: User,
+    service: SlackService,
+) -> None:
+    """구독 링크를 엽니다. 로깅을 위한 이벤트입니다."""
+    await ack()

--- a/app/slack/events/subscriptions.py
+++ b/app/slack/events/subscriptions.py
@@ -208,7 +208,7 @@ async def unsubscribe_target_user(
     if not subscription:
         await ack(
             response_action="errors",
-            errors={"unsubscribe_target_user": "구독을 찾을 수 없습니다."},
+            errors={"unsubscribe_target_user": "구독 내용을 찾을 수 없습니다."},
         )
         return
 

--- a/app/slack/events/subscriptions.py
+++ b/app/slack/events/subscriptions.py
@@ -1,0 +1,180 @@
+from app.constants import BOT_IDS
+from app.models import User
+from app.slack.services.base import SlackService
+from app.slack.types import (
+    ActionBodyType,
+    ViewBodyType,
+)
+
+from slack_sdk.models.blocks import (
+    Option,
+    OverflowMenuElement,
+    SectionBlock,
+    DividerBlock,
+    UserSelectElement,
+    InputBlock,
+    ContextBlock,
+    MarkdownTextObject,
+)
+from slack_sdk.models.views import View
+from slack_bolt.async_app import AsyncAck, AsyncSay
+from slack_sdk.web.async_client import AsyncWebClient
+
+
+async def subscribe_member_content_by_action(
+    ack: AsyncAck,
+    body: ActionBodyType,
+    say: AsyncSay,
+    client: AsyncWebClient,
+    user: User,
+    service: SlackService,
+) -> None:
+    """멤버 구독 모달을 엽니다."""
+    await ack()
+
+    view = _get_subscribe_member_content_view(user_id=user.user_id, service=service)
+
+    await client.views_open(
+        trigger_id=body["trigger_id"],
+        view=view,
+    )
+
+
+async def subscribe_member_content_by_view(
+    ack: AsyncAck,
+    body: ViewBodyType,
+    say: AsyncSay,
+    client: AsyncWebClient,
+    user: User,
+    service: SlackService,
+) -> None:
+    """멤버 구독 모달을 엽니다."""
+    await ack()
+
+    view = _get_subscribe_member_content_view(user_id=user.user_id, service=service)
+
+    await client.views_open(
+        trigger_id=body["trigger_id"],
+        view=view,
+    )
+
+
+def _get_subscribe_member_content_view(
+    *,
+    user_id: str,
+    service: SlackService,
+    initial_target_user_id: str | None = None,
+) -> View:
+    """구독 목록과, 멤버를 구독할 수 있는 뷰를 반환합니다."""
+    user_subscriptions = service.fetch_subscriptions_by_user_id(user_id=user_id)
+
+    subscription_list_blocks = [
+        SectionBlock(
+            text=f"<@{subscription.target_user_id}> 님을 {subscription.created_at} 부터 구독하고 있어요.",
+            accessory=OverflowMenuElement(
+                action_id="unsubscribe_target_user",
+                options=[
+                    Option(text="구독 취소", value=subscription.id),
+                ],
+            ),
+        )
+        for subscription in user_subscriptions
+    ]
+
+    if subscription_list_blocks:
+        subscription_list_blocks = [
+            SectionBlock(text="*구독 목록*"),
+            *subscription_list_blocks,
+        ]
+
+    view = View(
+        type="modal",
+        title="멤버 구독",
+        callback_id="handle_subscribe_member_content_view",
+        submit="구독하기",
+        close="닫기",
+        blocks=[
+            SectionBlock(
+                text=f"<@{user_id}> 님은 현재 {len(user_subscriptions)}명을 구독하고 있어요."
+            ),
+            DividerBlock(),
+            InputBlock(
+                block_id="select_target_user",
+                label="멤버 구독하기",
+                element=UserSelectElement(
+                    action_id="select",
+                    placeholder="구독할 멤버를 선택해주세요.",
+                    initial_user=initial_target_user_id,
+                ),
+            ),
+            ContextBlock(
+                elements=[
+                    MarkdownTextObject(
+                        text="구독한 멤버가 글을 제출하면 알림을 받아 볼 수 있는 기능입니다.\n"
+                        "알림은 글 제출 다음날 오전 8시(한국 시간)에 DM 으로 전달합니다.\n"
+                        "구독 취소는 구독 목록 우측 `...` 버튼을 눌러 취소할 수 있습니다.\n"
+                        "최대 5명까지 구독 할 수 있습니다.",
+                    ),
+                ],
+            ),
+            DividerBlock(),
+            *subscription_list_blocks,
+        ],
+    )
+
+    return view
+
+
+async def handle_subscribe_member_content_view(
+    ack: AsyncAck,
+    body: ViewBodyType,
+    say: AsyncSay,
+    client: AsyncWebClient,
+    user: User,
+    service: SlackService,
+) -> None:
+    """멤버 구독을 핸들링합니다."""
+    target_user_id = body["view"]["state"]["values"]["select_target_user"]["select"][
+        "selected_user"
+    ]
+
+    if target_user_id == user.user_id:
+        await ack(
+            response_action="errors",
+            errors={"select_target_user": "자기 자신은 구독할 수 없어요. 😅"},
+        )
+        return
+
+    if target_user_id in BOT_IDS:
+        await ack(
+            response_action="errors",
+            errors={"select_target_user": "봇은 구독할 수 없어요. 😉"},
+        )
+        return
+
+    if len(service.fetch_subscriptions_by_user_id(user_id=user.user_id)) >= 5:
+        await ack(
+            response_action="errors",
+            errors={"select_target_user": "구독은 최대 5명까지 가능해요. 😭"},
+        )
+        return
+
+    await ack()
+
+    service.create_subscription(user_id=user.user_id, target_user_id=target_user_id)
+
+    await client.views_open(
+        trigger_id=body["trigger_id"],
+        view=View(
+            type="modal",
+            title="멤버 구독 완료",
+            callback_id="subscribe_member_content_by_view",
+            blocks=[
+                SectionBlock(
+                    text=f"<@{target_user_id}> 님의 글 구독을 시작합니다! 🤩",
+                ),
+            ],
+            submit="돌아가기",
+            close="닫기",
+        ),
+    )

--- a/app/slack/repositories.py
+++ b/app/slack/repositories.py
@@ -19,6 +19,12 @@ class SlackRepository:
             return user
         return None
 
+    def get_only_user(self, user_id: str) -> models.User | None:
+        """유저만 가져옵니다."""
+        if user := self._get_user(user_id):
+            return user
+        return None
+
     def fetch_users(self) -> list[models.User]:
         """모든 유저를 가져옵니다."""
         users = [models.User(**user) for user in self._fetch_users()]
@@ -302,6 +308,17 @@ class SlackRepository:
             models.SubscriptionStatusEnum.DELETED
         )
         df.to_csv("store/subscriptions.csv", index=False, quoting=csv.QUOTE_ALL)
+
+    def fetch_subscriptions(self) -> list[models.Subscription]:
+        """모든 구독 내역을 가져옵니다."""
+        with open("store/subscriptions.csv") as f:
+            reader = csv.DictReader(f)
+            subscriptions = [
+                models.Subscription(**subscription)  # type: ignore
+                for subscription in reader
+                if subscription["status"] == models.SubscriptionStatusEnum.ACTIVE
+            ]
+            return subscriptions
 
     def fetch_subscriptions_by_user_id(
         self,

--- a/app/slack/repositories.py
+++ b/app/slack/repositories.py
@@ -305,7 +305,7 @@ class SlackRepository:
         """구독을 취소합니다."""
         df = pd.read_csv("store/subscriptions.csv", dtype=str, na_filter=False)
         df.loc[df["id"] == subscription_id, "status"] = (
-            models.SubscriptionStatusEnum.DELETED
+            models.SubscriptionStatusEnum.CANCELED
         )
         df.to_csv("store/subscriptions.csv", index=False, quoting=csv.QUOTE_ALL)
 
@@ -350,11 +350,18 @@ class SlackRepository:
             ]
             return subscriptions
 
-    def get_subscription(self, subscription_id: str) -> models.Subscription | None:
+    def get_subscription(
+        self,
+        subscription_id: str,
+        status: models.SubscriptionStatusEnum = models.SubscriptionStatusEnum.ACTIVE,
+    ) -> models.Subscription | None:
         """구독을 가져옵니다."""
         with open("store/subscriptions.csv") as f:
             reader = csv.DictReader(f)
             for subscription in reader:
-                if subscription["id"] == subscription_id:
+                if (
+                    subscription["id"] == subscription_id
+                    and subscription["status"] == status
+                ):
                     return models.Subscription(**subscription)  # type: ignore
         return None

--- a/app/slack/repositories.py
+++ b/app/slack/repositories.py
@@ -295,6 +295,14 @@ class SlackRepository:
             writer = csv.writer(f, quoting=csv.QUOTE_ALL)
             writer.writerow(subscription.to_list_for_csv())
 
+    def cancel_subscription(self, subscription_id: str) -> None:
+        """구독을 취소합니다."""
+        df = pd.read_csv("store/subscriptions.csv", dtype=str, na_filter=False)
+        df.loc[df["id"] == subscription_id, "status"] = (
+            models.SubscriptionStatusEnum.DELETED
+        )
+        df.to_csv("store/subscriptions.csv", index=False, quoting=csv.QUOTE_ALL)
+
     def fetch_subscriptions_by_user_id(
         self,
         user_id: str,
@@ -324,3 +332,12 @@ class SlackRepository:
                 and subscription["target_user_id"] == target_user_id
             ]
             return subscriptions
+
+    def get_subscription(self, subscription_id: str) -> models.Subscription | None:
+        """구독을 가져옵니다."""
+        with open("store/subscriptions.csv") as f:
+            reader = csv.DictReader(f)
+            for subscription in reader:
+                if subscription["id"] == subscription_id:
+                    return models.Subscription(**subscription)  # type: ignore
+        return None

--- a/app/slack/repositories.py
+++ b/app/slack/repositories.py
@@ -288,3 +288,39 @@ class SlackRepository:
                 if paper_plane["sender_id"] == sender_id
             ]
             return paper_planes
+
+    def create_subscription(self, subscription: models.Subscription) -> None:
+        """구독을 생성합니다."""
+        with open("store/subscriptions.csv", "a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f, quoting=csv.QUOTE_ALL)
+            writer.writerow(subscription.to_list_for_csv())
+
+    def fetch_subscriptions_by_user_id(
+        self,
+        user_id: str,
+    ) -> list[models.Subscription]:
+        """유저의 구독 내역을 가져옵니다."""
+        with open("store/subscriptions.csv") as f:
+            reader = csv.DictReader(f)
+            subscriptions = [
+                models.Subscription(**subscription)  # type: ignore
+                for subscription in reader
+                if subscription["status"] == models.SubscriptionStatusEnum.ACTIVE
+                and subscription["user_id"] == user_id
+            ]
+            return subscriptions
+
+    def fetch_subscriptions_by_target_user_id(
+        self,
+        target_user_id: str,
+    ) -> list[models.Subscription]:
+        """타겟 유저를 기준으로 구독 내역을 가져옵니다."""
+        with open("store/subscriptions.csv") as f:
+            reader = csv.DictReader(f)
+            subscriptions = [
+                models.Subscription(**subscription)  # type: ignore
+                for subscription in reader
+                if subscription["status"] == models.SubscriptionStatusEnum.ACTIVE
+                and subscription["target_user_id"] == target_user_id
+            ]
+            return subscriptions

--- a/app/slack/services/background.py
+++ b/app/slack/services/background.py
@@ -177,6 +177,7 @@ class BackgroundService:
                             ButtonElement(
                                 text="감사의 종이비행기 보내기",
                                 action_id="send_paper_plane_message",
+                                value=row["target_user_id"],
                             ),
                         ]
                     ),

--- a/app/slack/services/background.py
+++ b/app/slack/services/background.py
@@ -1,14 +1,28 @@
+import csv
+from datetime import timedelta
+import traceback
+
+import pandas as pd
 from app.constants import remind_message
 from app.logging import log_event
 from app.models import User
 from app.slack.repositories import SlackRepository
-
+from slack_sdk.models.blocks import (
+    SectionBlock,
+    TextObject,
+    ActionsBlock,
+    ContextBlock,
+    ButtonElement,
+    DividerBlock,
+)
 
 from slack_bolt.async_app import AsyncApp
 from app.config import settings
 
 
 import asyncio
+
+from app.utils import dict_to_json_str, tz_now
 
 
 class BackgroundService:
@@ -51,3 +65,136 @@ class BackgroundService:
             channel=settings.ADMIN_CHANNEL,
             text=f"총 {len(target_users)} 명에게 리마인드 메시지를 전송했습니다.",
         )
+
+    async def prepare_subscribe_message_data(self) -> None:
+        """사용자에게 구독 알림 메시지 목록을 임시 CSV 파일로 저장합니다."""
+
+        # 모든 구독 정보를 가져옵니다
+        subscriptions = self._repo.fetch_subscriptions()
+
+        # 구독 대상자들의 user_id를 중복 없이 set으로 추출합니다
+        target_user_ids = {
+            subscription.target_user_id for subscription in subscriptions
+        }
+
+        yesterday = (tz_now() - timedelta(days=1)).date()
+        contents_df = pd.read_csv("store/contents.csv")
+
+        # dt 컬럼을 datetime 타입으로 변환하고 date 부분만 추출합니다
+        contents_df["dt"] = pd.to_datetime(contents_df["dt"]).dt.date
+
+        # 구독 대상자의 콘텐츠 중 어제 작성된 것만 필터링합니다
+        filtered_contents = contents_df[
+            (contents_df["user_id"].isin(target_user_ids))
+            & (contents_df["dt"] == yesterday)
+        ]
+
+        # 구독 알림 메시지 데이터를 저장할 리스트
+        subscription_messages = []
+
+        # 각 구독 대상자별로 처리를 시작합니다
+        for target_user_id in target_user_ids:
+            target_contents = filtered_contents[
+                filtered_contents["user_id"] == target_user_id
+            ]
+
+            # 해당 구독 대상자의 콘텐츠가 없으면 다음 대상자로 넘어갑니다
+            if len(target_contents) == 0:
+                continue
+
+            # 현재 구독 대상자를 구독하는 모든 구독자 정보를 가져옵니다
+            target_subscriptions = self._repo.fetch_subscriptions_by_target_user_id(
+                target_user_id
+            )
+
+            # 구독자에게 보낼 알림을 배열에 담습니다.
+            for subscription in target_subscriptions:
+                for _, content in target_contents.iterrows():
+                    subscription_messages.append(
+                        {
+                            "user_id": subscription.user_id,
+                            "target_user_id": target_user_id,
+                            "target_user_channel": subscription.target_user_channel,
+                            "ts": content["ts"],
+                            "title": content["title"],
+                            "dt": content["dt"],
+                        }
+                    )
+
+        # 임시 CSV 파일에 저장합니다.
+        if subscription_messages:
+            pd.DataFrame(subscription_messages).to_csv(
+                "store/_subscription_messages.csv",
+                index=False,
+                quoting=csv.QUOTE_ALL,
+            )
+
+    async def send_subscribe_message_to_user(self, slack_app: AsyncApp) -> None:
+        """사용자에게 구독 알림 메시지를 전송합니다."""
+        df = pd.read_csv("store/_subscription_messages.csv")
+        for _, row in df.iterrows():
+            try:
+                permalink_res = await slack_app.client.chat_getPermalink(
+                    message_ts=row["ts"],
+                    channel=row["target_user_channel"],
+                )
+
+                text = f"구독하신 <@{row['target_user_id']}>님의 새로운 글이 올라왔어요! 🤩"
+                blocks = [
+                    SectionBlock(
+                        text=text,
+                    ),
+                    ContextBlock(
+                        elements=[
+                            TextObject(
+                                type="mrkdwn",
+                                text=f"글 제목 : {row['title']}\n제출 날짜 : {row['dt'][:4]}년 {int(row['dt'][5:7])}월 {int(row['dt'][8:10])}일",
+                            ),
+                        ],
+                    ),
+                    ActionsBlock(
+                        elements=[
+                            ButtonElement(
+                                text="글 보러가기",
+                                action_id="open_subscription_permalink",
+                                url=permalink_res["permalink"],
+                                style="primary",
+                                value=dict_to_json_str(
+                                    {
+                                        "user_id": row["user_id"],  # 구독자
+                                        "ts": row["ts"],  # 클릭한 콘텐츠 id
+                                    }
+                                ),
+                            ),
+                            ButtonElement(
+                                text="감사의 종이비행기 보내기",
+                                action_id="send_paper_plane_message",
+                            ),
+                        ]
+                    ),
+                    DividerBlock(),
+                ]
+                await slack_app.client.chat_postMessage(
+                    channel=row["user_id"],
+                    text=text,
+                    blocks=blocks,
+                )
+
+                # 슬랙은 메시지 전송을 초당 1개를 권장하기 때문에 1초 대기합니다.
+                # 참고문서: https://api.slack.com/methods/chat.postMessage#rate_limiting
+                await asyncio.sleep(1)
+
+            except Exception as e:
+                trace = traceback.format_exc()
+                message = f"⚠️ <@{row['user_id']}>님의 구독 알림 메시지 전송에 실패했습니다. 오류: {e} {trace}"
+                log_event(
+                    actor="slack_subscribe_service",
+                    event="send_subscribe_message_to_user",
+                    type="error",
+                    description=message,
+                )
+                await slack_app.client.chat_postMessage(
+                    channel=settings.ADMIN_CHANNEL,
+                    text=message,
+                )
+                continue

--- a/app/slack/services/base.py
+++ b/app/slack/services/base.py
@@ -394,3 +394,28 @@ class SlackService:
                 paper_planes.append(plane)
 
         return paper_planes
+
+    def fetch_subscriptions_by_user_id(
+        self,
+        user_id: str,
+    ) -> list[models.Subscription]:
+        """유저의 구독 내역을 가져옵니다."""
+        return self._repo.fetch_subscriptions_by_user_id(user_id)
+
+    def fetch_subscriptions_by_target_user_id(
+        self,
+        target_user_id: str,
+    ) -> list[models.Subscription]:
+        """타겟 유저를 기준으로 구독 내역을 가져옵니다."""
+        return self._repo.fetch_subscriptions_by_target_user_id(target_user_id)
+
+    def create_subscription(
+        self, user_id: str, target_user_id: str
+    ) -> models.Subscription:
+        """구독을 생성합니다."""
+        subscription = models.Subscription(
+            user_id=user_id, target_user_id=target_user_id
+        )
+        self._repo.create_subscription(subscription)
+        store.subscription_upload_queue.append(subscription.to_list_for_sheet())
+        return subscription

--- a/app/slack/services/base.py
+++ b/app/slack/services/base.py
@@ -419,3 +419,11 @@ class SlackService:
         self._repo.create_subscription(subscription)
         store.subscription_upload_queue.append(subscription.to_list_for_sheet())
         return subscription
+
+    def get_subscription(self, subscription_id: str) -> models.Subscription | None:
+        """구독을 가져옵니다."""
+        return self._repo.get_subscription(subscription_id)
+
+    def cancel_subscription(self, subscription_id: str) -> None:
+        """구독을 취소합니다."""
+        self._repo.cancel_subscription(subscription_id)

--- a/app/slack/services/base.py
+++ b/app/slack/services/base.py
@@ -429,3 +429,8 @@ class SlackService:
     def cancel_subscription(self, subscription_id: str) -> None:
         """구독을 취소합니다."""
         self._repo.cancel_subscription(subscription_id)
+        subscription = self._repo.get_subscription(
+            subscription_id, status=models.SubscriptionStatusEnum.CANCELED
+        )
+        if subscription:
+            store.subscription_update_queue.append(subscription.model_dump())

--- a/app/slack/services/base.py
+++ b/app/slack/services/base.py
@@ -45,8 +45,15 @@ class SlackService:
         return contents
 
     def get_user(self, user_id) -> models.User:
-        """유저 정보를 가져옵니다."""
+        """유저와 콘텐츠 정보를 가져옵니다."""
         user = self._repo.get_user(user_id)
+        if not user:
+            raise BotException("해당 유저 정보가 없어요.")
+        return user
+
+    def get_only_user(self, user_id) -> models.User:
+        """유저 정보만 가져옵니다."""
+        user = self._repo.get_only_user(user_id)
         if not user:
             raise BotException("해당 유저 정보가 없어요.")
         return user
@@ -402,19 +409,14 @@ class SlackService:
         """유저의 구독 내역을 가져옵니다."""
         return self._repo.fetch_subscriptions_by_user_id(user_id)
 
-    def fetch_subscriptions_by_target_user_id(
-        self,
-        target_user_id: str,
-    ) -> list[models.Subscription]:
-        """타겟 유저를 기준으로 구독 내역을 가져옵니다."""
-        return self._repo.fetch_subscriptions_by_target_user_id(target_user_id)
-
     def create_subscription(
-        self, user_id: str, target_user_id: str
+        self, user_id: str, target_user_id: str, target_user_channel: str
     ) -> models.Subscription:
         """구독을 생성합니다."""
         subscription = models.Subscription(
-            user_id=user_id, target_user_id=target_user_id
+            user_id=user_id,
+            target_user_id=target_user_id,
+            target_user_channel=target_user_channel,
         )
         self._repo.create_subscription(subscription)
         store.subscription_upload_queue.append(subscription.to_list_for_sheet())


### PR DESCRIPTION
또봇 홈 탭에서 멤버 구독하기 버튼을 통해 특정 멤버를 구독할 수 있습니다.
구독 대상자가 글을 제출하면 다음날 오전 8시에 디엠으로 알림을 전송합니다.

자세한 내용은 [개발 문서](https://www.notion.so/zzsza/159c2493491a41668704cbc23d632b9f)를 참고해주세요.


### 결과 이미지

또봇 홈 탭
![image](https://github.com/user-attachments/assets/c6355c88-8066-4fe8-b4dd-bb18cf3ea79f)

구독하기 모달
![image](https://github.com/user-attachments/assets/73e9e701-198a-4e0f-9630-7d635d23141c)

구독 알림
![image](https://github.com/user-attachments/assets/a49c5554-6dbb-48fc-aa0e-481a6052e82a)

